### PR TITLE
[Log] Report unhandled top-level error to log, not stderr.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod macros;
 // mod arcball;
 mod fps;
 mod logging;
+use log::error;
 
 mod hub;
 use self::hub::Hub;
@@ -24,12 +25,14 @@ fn run() -> Result<Infallible> {
 }
 
 fn main() {
+    // Configure logging engine:
     logging::setup();
 
     if let Err(err) = run() {
-        eprintln!("Error: {}", err);
+        // We panic'd somewhere.  Report the error, and its causes, to the log.
+        error!("Unhandled error: {}", err);
         for cause in err.chain().skip(1) {
-            eprintln!("because: {}", cause);
+            error!("because: {}", cause);
         }
         std::process::exit(1);
     }


### PR DESCRIPTION
If an unhandled error propagates to the top of the main loop, that's something that should end up in the log.  Right now the log prints to stderr too, but eventually it will be routed to a file and we won't want to lose our error reporting then.