### PR TITLE
Add Fedora build instructions. Introduce containerized build runbook for Linux workstations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ files.
 1. [Install Rust](https://rustup.rs/)
 2. Install build dependencies: 
     - __macOS__: `brew install cmake`
-    - __debian/ubuntu__: `apt install build-essential cmake libx11-dev` 
+    - __Debian/Ubuntu__: `apt install build-essential cmake libx11-dev` 
+    - __RHEL/Fedora__: `dnf groupinstall "Development Tools" && dnf install gcc-c++ cmake libX11-devel`
     - __Windows__ 
         - [Install Git](https://git-scm.com/download/win)
         - [Install CMake](https://cmake.org/download/)
@@ -26,7 +27,8 @@ If your browser supports WebGPU, you can run atomCAD in your browser:
 1. [Install Rust](https://rustup.rs/)
 2. Install build dependencies: 
     - __macOS__: `brew install cmake`
-    - __debian/ubuntu__: `apt install build-essential cmake libx11-dev` 
+    - __Debian/Ubuntu__: `apt install build-essential cmake libx11-dev` 
+    - __RHEL/Fedora__: `dnf groupinstall "Development Tools" && dnf install gcc-c++ cmake libX11-devel`
     - __Windows__ 
         - [Install Git](https://git-scm.com/download/win)
         - [Install CMake](https://cmake.org/download/)

--- a/build-distrobox.md
+++ b/build-distrobox.md
@@ -1,0 +1,31 @@
+# Containerized Linux Build Environment with Distrobox
+
+The standard AtomCAD build instructions for Linux involve installing the C/C++ dependencies with your system's package manager.  Sometimes this is not an option, whether because your employer requires you to use a distro that's too old, like RHEL or an old Ubuntu LTS, or your distro has an immutable base and will become fragile with that many packages layered on top of it, like Fedora Silverblue.  For server software, Docker is the standard Linux container platform, but Docker doesn't have the GUI or home filesystem integration needed for a dev container for GUI software like AtomCAD.  That's where Distrobox comes in.  Distrobox is a wrapper around [Podman](https://podman.io), which keeps the OS packages separate while preconfiguring integration of X11, Wayland, PulseAudio, your home filesystem, and your user's username/uid/gid.  This isn't particularly secure, but it does keep your base OS cleaner.  Docker is still recommended for headless CI/CD.
+
+## Installing the Tools
+
+1. Install Rust to your home directory with [RustUp](https://rustup.rs).
+
+2. Install [Distrobox](https://github.com/89luca89/distrobox).
+
+## Creating the Container
+
+```
+user@host $ distrobox create --name atomcad-dev --image $distro_docker_image:$tag
+```
+
+NOTE: if your system uses an Nvidia GPU, add the `--nvidia` flag to `distrobox create`.
+
+## Setting up the Environment
+
+```
+user@host $ distrobox enter atomcad-dev
+# Ubuntu
+user@atomcad-dev $ sudo apt install build-essential cmake libx11-dev
+# Fedora
+user@atomcad-dev $ sudo dnf groupinstall "Development Tools" && sudo dnf install gcc-c++ cmake libX11-devel
+```
+
+## Start Developing
+
+Once your dependencies are installed, open up AtomCAD in your editor, run `distrobox enter atomcad-dev` in your preferred terminal, and invoke `cargo run`.  The AtomCAD window should open at the end of the build as usual.


### PR DESCRIPTION
When I first attempted to build AtomCAD in a regular headless container, I was able to run cargo build successfully, but I hit strange "incompatible shader format" errors when attempting to run AtomCAD with cargo run. Switching my build environment to Distrobox ( https://github.com/89luca89/distrobox ) fixed the shader errors and allowed me to launch AtomCAD. This pull request documents the process of using Rustup+Distrobox to create isolated, disposable build environments with no system package dependencies outside of Distrobox and Podman.