### PR TITLE
add CI badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # atomCAD
 
+![CI status](https://github.com/atomCAD/atomCAD/actions/workflows/ci.yml/badge.svg)
+
 A CAD/CAM environment for designing atomically-precise molecular nanotechnology.
 Eventually.  Right now it's a decently fast molecular viewer able to parse PDB
 files.


### PR DESCRIPTION
Quick PR to embed a CI run status badge at the top of the readme so it's visible without tabbing over to "Actions".