### PR TITLE
Atom Screen Picking & minor cleanup

### DIFF
--- a/crates/render/src/camera.rs
+++ b/crates/render/src/camera.rs
@@ -23,11 +23,7 @@ pub trait Camera {
     fn update(&mut self, event: InputEvent) -> bool;
     fn finalize(&mut self);
     fn repr(&self) -> CameraRepr;
-    fn get_ray_from(
-        &self,
-        pixel: &PhysicalPosition<f64>,
-        viewport_size: &PhysicalSize<u32>,
-    ) -> (Vec3, Vec3);
+    fn position(&self) -> Vec3;
 }
 
 pub struct RenderCamera {
@@ -131,8 +127,39 @@ impl RenderCamera {
         // }
     }
 
-    pub fn camera(&self) -> &Option<Box<dyn Camera>> {
-        &self.camera
+    pub fn get_ray_from(
+        &self,
+        pixel: &PhysicalPosition<f64>,
+        viewport_size: &PhysicalSize<u32>,
+    ) -> Option<(Vec3, Vec3)> {
+        println!();
+        let camera = self.camera.as_ref()?;
+        let camera_repr = camera.repr();
+
+        // 1. Convert the pixel position to normalized device coordinates.
+        let x = (2.0 * pixel.x as f32 - viewport_size.width as f32) / viewport_size.width as f32;
+        let y = (viewport_size.height as f32 - 2.0 * pixel.y as f32) / viewport_size.height as f32;
+
+        // 2. Create a ray in clip space.
+        let ray_clip = Vec3::new(x, y, -self.near);
+        dbg!(self.near);
+
+        // 3. Inverse project this ray from clip space to camera's view space.
+        let proj_inv = camera_repr.projection.inversed();
+        let ray_eye = proj_inv.transform_vec3(ray_clip);
+
+        // For the perspective projection, we need to flip the direction along the z-axis
+        let ray_eye = Vec3::new(ray_eye.x, ray_eye.y, -1.0);
+
+        // 4. Inverse transform this ray from the camera's view space to world space.
+        let view_inv = camera_repr.view.inversed();
+        let ray_world = view_inv.transform_vec3(ray_eye);
+
+        // Normalize the ray's direction
+        let ray_dir = ray_world.normalized();
+
+        dbg!(&ray_dir);
+        Some((camera.position(), ray_dir))
     }
 }
 

--- a/crates/render/src/camera.rs
+++ b/crates/render/src/camera.rs
@@ -142,7 +142,6 @@ impl RenderCamera {
 
         // 2. Create a ray in clip space.
         let ray_clip = Vec3::new(x, y, -self.near);
-        dbg!(self.near);
 
         // 3. Inverse project this ray from clip space to camera's view space.
         let proj_inv = camera_repr.projection.inversed();
@@ -158,7 +157,6 @@ impl RenderCamera {
         // Normalize the ray's direction
         let ray_dir = ray_world.normalized();
 
-        dbg!(&ray_dir);
         Some((camera.position(), ray_dir))
     }
 }

--- a/crates/scene/src/assembly.rs
+++ b/crates/scene/src/assembly.rs
@@ -41,14 +41,14 @@ impl Assembly {
         }
     }
 
-    pub fn walk_mut(&self, mut f: impl FnMut(&Molecule, Mat4)) {
-        let mut stack: Vec<(&Assembly, Mat4)> = vec![(self, Mat4::default())];
+    pub fn walk_mut(&mut self, mut f: impl FnMut(&mut Molecule, Mat4)) {
+        let mut stack: Vec<(&mut Assembly, Mat4)> = vec![(self, Mat4::default())];
 
         while let Some((assembly, acc_transform)) = stack.pop() {
-            for component in &assembly.components {
+            for component in &mut assembly.components {
                 let new_transform = component.transform * acc_transform;
-                match &component.data {
-                    ComponentType::Molecule(molecule) => {
+                match &mut component.data {
+                    ComponentType::Molecule(ref mut molecule) => {
                         f(molecule, new_transform);
                     }
                     ComponentType::SubAssembly(sub_assembly) => {

--- a/crates/scene/src/feature.rs
+++ b/crates/scene/src/feature.rs
@@ -55,11 +55,14 @@ impl Feature for RootAtom {
         feature_id: &FeatureId,
         commands: &mut dyn MoleculeCommands,
     ) -> Result<(), FeatureError> {
-        commands.add_atom(
-            self.element,
-            Default::default(),
-            AtomSpecifier::new(*feature_id),
-        )?;
+        let pos = match self.element {
+            Element::Phosphorus => ultraviolet::Vec3::new(5.0, 0.0, 0.0),
+            Element::Nitrogen => ultraviolet::Vec3::new(0.0, 0.0, 5.0),
+            Element::Xenon => ultraviolet::Vec3::new(0.0, 5.0, 0.0),
+            _ => Default::default(),
+        };
+
+        commands.add_atom(self.element, pos, AtomSpecifier::new(*feature_id))?;
 
         Ok(())
     }
@@ -78,17 +81,15 @@ impl Feature for AtomFeature {
     ) -> Result<(), FeatureError> {
         let spec = AtomSpecifier::new(*feature_id);
 
-        let x = {
+        let mut pos = {
             let atom = commands.find_atom(&self.target);
             let atom = atom.ok_or(FeatureError::BrokenReference(ReferenceType::Atom))?;
-            atom.pos.x + 5.0
+            atom.pos
         };
 
-        commands.add_atom(
-            self.element,
-            ultraviolet::Vec3::new(x, 0.0, 0.0),
-            spec.clone(),
-        )?;
+        pos.x += 5.0;
+
+        commands.add_atom(self.element, pos, spec.clone())?;
 
         commands.create_bond(&self.target, &spec, 1)?;
 

--- a/crates/scene/src/molecule.rs
+++ b/crates/scene/src/molecule.rs
@@ -213,9 +213,6 @@ impl Molecule {
                 // TODO: Bubble error to the user
                 println!("Feature reconstruction error on feature {}", feature_id);
             }
-
-            dbg!(&self.repr.bounding_box);
-            println!();
         }
 
         self.history_step = history_step;
@@ -241,13 +238,11 @@ impl Molecule {
         &self.gpu_atoms
     }
 
-    pub fn get_ray_hit(&self, origin: Vec3, direction: Vec3) -> Option<AtomIndex> {
+    pub fn get_ray_hit(&self, origin: Vec3, direction: Vec3) -> Option<AtomSpecifier> {
         // Using `direction` as a velocity vector, determine when the ray will
         // collide with the bounding box. Note the ? - this fn returns early if there
         // isn't a collision.
         let (tmin, tmax) = self.repr.bounding_box.ray_hit_times(origin, direction)?;
-        println!("got a ray");
-        dbg!(tmin, tmax);
 
         // If the box is fully behind the raycast direction, we will never get a hit.
         if tmax <= 0.0 {
@@ -267,10 +262,22 @@ impl Molecule {
         // the user clicks on the very edge of it, but this is rare.
         let step_size = PERIODIC_TABLE.element_reprs[Element::Hydrogen as usize].radius / 10.0;
         let step = direction * step_size;
+        let t_span = tmax - f32::max(0.0, tmin);
+        // the direction vector is normalized, so 1 unit of time = 1 unit of space
+        let num_steps = (t_span / step_size) as usize;
 
-        while self.repr.bounding_box.contains(current_pos) {
-            // Placeholder for additional logic
-            dbg!(&current_pos);
+        let graph = &self.repr.graph;
+        for _ in 0..num_steps {
+            for atom_index in graph.node_indices() {
+                let atom = graph.node_weight(atom_index).expect("Iterating over an immutably referenced graph should always provide valid node indexes");
+                let atom_radius_sq = PERIODIC_TABLE.element_reprs[atom.element as usize]
+                    .radius
+                    .powi(2);
+
+                if (current_pos - atom.pos).mag_sq() < atom_radius_sq {
+                    return Some(atom.spec.clone());
+                }
+            }
 
             current_pos += step;
         }

--- a/crates/scene/src/utils.rs
+++ b/crates/scene/src/utils.rs
@@ -62,7 +62,9 @@ impl BoundingBox {
     fn intersection_times(origin: f32, speed: f32, min: f32, max: f32) -> Option<(f32, f32)> {
         // If the speed is non-zero, we can compute the times normally.
         if speed != 0.0 {
-            Some(((min - origin) / speed, (max - origin) / speed))
+            let t1 = (min - origin) / speed;
+            let t2 = (max - origin) / speed;
+            Some((f32::min(t1, t2), f32::max(t1, t2)))
         }
         // If the speed is zero and the origin is within the bounding slab
         // along that axis, the ray runs parallel to the slab. We represent this as

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -15,7 +15,7 @@ use common::InputEvent;
 use render::{Camera, CameraRepr};
 use ultraviolet::{projection, Mat4, Vec3};
 use winit::{
-    dpi::{PhysicalPosition, PhysicalSize},
+    dpi::PhysicalPosition,
     event::{DeviceEvent, ElementState, MouseButton, MouseScrollDelta, WindowEvent},
 };
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -72,16 +72,6 @@ impl ArcballCamera {
     fn add_pitch(&mut self, dpitch: f32) {
         self.pitch = clamp(self.pitch + dpitch, (-PI / 2.0) + 0.001, (PI / 2.0) - 0.001);
     }
-
-    fn position(&self) -> Vec3 {
-        self.focus
-            + self.distance
-                * Vec3::new(
-                    self.yaw.sin() * self.pitch.cos(),
-                    self.yaw.cos() * self.pitch.cos(),
-                    self.pitch.sin(),
-                )
-    }
 }
 
 impl Camera for ArcballCamera {
@@ -137,33 +127,14 @@ impl Camera for ArcballCamera {
         self.camera.clone()
     }
 
-    fn get_ray_from(
-        &self,
-        pixel: &PhysicalPosition<f64>,
-        viewport_size: &PhysicalSize<u32>,
-    ) -> (Vec3, Vec3) {
-        // 1. Convert the pixel position to normalized device coordinates.
-        let x = (2.0 * pixel.x as f32 - viewport_size.width as f32) / viewport_size.width as f32;
-        let y = (viewport_size.height as f32 - 2.0 * pixel.y as f32) / viewport_size.height as f32;
-
-        // 2. Create a ray in clip space.
-        let ray_clip = Vec3::new(x, y, 1.0); // The -1.0 assumes the near plane is at z=-1 in clip space
-
-        // 3. Inverse project this ray from clip space to camera's view space.
-        let proj_inv = self.camera.projection.inversed();
-        let ray_eye = proj_inv.transform_vec3(ray_clip);
-
-        // For the perspective projection, we need to flip the direction along the z-axis
-        let ray_eye = Vec3::new(ray_eye.x, ray_eye.y, -1.0);
-
-        // 4. Inverse transform this ray from the camera's view space to world space.
-        let view_inv = self.camera.view.inversed();
-        let ray_world = view_inv.transform_vec3(ray_eye);
-
-        // Normalize the ray's direction
-        let ray_dir = ray_world.normalized();
-
-        (self.position(), ray_dir)
+    fn position(&self) -> Vec3 {
+        self.focus
+            + self.distance
+                * Vec3::new(
+                    self.yaw.sin() * self.pitch.cos(),
+                    self.yaw.cos() * self.pitch.cos(),
+                    self.pitch.sin(),
+                )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,10 +64,7 @@ use camera::ArcballCamera;
 use common::InputEvent;
 use pdb::PdbFeature;
 use render::{GlobalRenderResources, Interactions, RenderOptions, Renderer};
-use scene::{
-    feature::{AtomFeature, RootAtom},
-    Assembly, Component, Molecule,
-};
+use scene::{Assembly, Component, Molecule};
 
 use std::rc::Rc;
 use ultraviolet::{Mat4, Vec3};
@@ -81,7 +78,7 @@ use winit::{
 
 fn make_pdb_demo_scene(gpu_resources: &GlobalRenderResources) -> Molecule {
     Molecule::from_feature(
-        &gpu_resources,
+        gpu_resources,
         PdbFeature {
             name: "Neon Pump".into(),
             contents: include_str!("../assets/neon_pump_imm.pdb").into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,35 +102,7 @@ async fn resume_renderer(
     .await;
 
     let molecule = make_pdb_demo_scene(&gpu_resources);
-
     let assembly = Assembly::from_components([Component::from_molecule(molecule, Mat4::default())]);
-
-    // The PDB parser lib3dmol does not parse connectivity information.
-    // Because of this, we cannot build a molecule graph out of a PDB,
-    // and so for now we use this hardcoded molecule to test the graph
-    // implementation:
-
-    // let mut neon_pump = pdb::load_from_pdb_str(
-    //     &gpu_resources,
-    //     "Neon Pump",
-    //     include_str!("../assets/neon_pump_imm.pdb"),
-    // )
-    // .expect("failed to load pdb");
-    // println!(
-    //     "Loaded {} parts and {} fragments",
-    //     neon_pump.parts().len(),
-    //     neon_pump.fragments().len()
-    // );
-    // // Center the neon pump around the origin, so that the rotating arcball
-    // // camera will be centered on it.
-    // for part in neon_pump.parts_mut() {
-    //     // This doesn't let the world know that this part is going to be
-    //     // updated, but we're adding them for the first time, so it'll work
-    //     // anyhow.
-    //     part.move_to(0.0, 0.0, 0.0);
-    // }
-    // world.merge(neon_pump);
-
     let interactions = Interactions::default();
 
     (renderer, gpu_resources, assembly, interactions)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,12 +217,18 @@ fn handle_event(
                         if key.physical_key == KeyCode::Space && key.state == ElementState::Released
                         {
                             if let Some(window) = window {
-                                if let Some(camera) = renderer.camera().camera() {
-                                    let (ray_origin, ray_direction) =
-                                        camera.get_ray_from(cursor_pos, &window.inner_size());
-                                    world.as_mut().unwrap().walk_mut(|molecule, _| {
-                                        molecule.get_ray_hit(ray_origin, ray_direction);
-                                    });
+                                match renderer
+                                    .camera()
+                                    .get_ray_from(cursor_pos, &window.inner_size())
+                                {
+                                    Some((ray_origin, ray_direction)) => {
+                                        world.as_mut().unwrap().walk_mut(|molecule, _| {
+                                            molecule.get_ray_hit(ray_origin, ray_direction);
+                                        });
+                                    }
+                                    None => {
+                                        println!("failed to create ray!");
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
`main` currently contains the skeleton of some atom picking code, but I couldn't get it working before my last PR. This fixes it (including a needed refactor - I didn't have the organization quite right) and ties it into the event loop. Now, when you press the spacebar, atomCAD prints the atom under your cursor to stdout.

I ran check.sh and have no warnings or formatting errors. Let me know if there are any needed changes :)