### PR TITLE
Serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ common = { package = "atomcad-common", path = "crates/common" }
 periodic-table = { package = "atomcad-periodic-table", path = "crates/periodic-table" }
 scene = { package = "atomcad-scene", path = "crates/scene" }
 ultraviolet = "0.9.1"
+serde = { version = "1.0.188", features = ["derive"] }
+serde_json = "1.0.105"
 
 
 [dependencies]
@@ -34,7 +36,6 @@ scene = { workspace = true }
 ultraviolet = { workspace = true }
 futures = "0.3.28"
 log = "0.4.19"
-lib3dmol = "0.4"
 nom = "7.1.3"
 winit = { git = "https://github.com/rust-windowing/winit", rev = "924f3323b56190ef93829af080fcca046c19bc80", features = [
     "android-native-activity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ render = { package = "atomcad-render", path = "crates/render" }
 common = { package = "atomcad-common", path = "crates/common" }
 periodic-table = { package = "atomcad-periodic-table", path = "crates/periodic-table" }
 scene = { package = "atomcad-scene", path = "crates/scene" }
-ultraviolet = "0.9.1"
+ultraviolet = { version = "0.9.1", features = ["serde"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 
@@ -34,6 +34,8 @@ common = { workspace = true }
 periodic-table = { workspace = true }
 scene = { workspace = true }
 ultraviolet = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 futures = "0.3.28"
 log = "0.4.19"
 nom = "7.1.3"

--- a/crates/periodic-table/Cargo.toml
+++ b/crates/periodic-table/Cargo.toml
@@ -12,5 +12,6 @@ edition = "2021"
 
 [dependencies]
 ultraviolet = { workspace = true }
-static_assertions = "1"
 common = { workspace = true }
+serde = { workspace = true }
+static_assertions = "1"

--- a/crates/periodic-table/src/lib.rs
+++ b/crates/periodic-table/src/lib.rs
@@ -3,12 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use common::AsBytes;
+use serde::{Deserialize, Serialize};
 use static_assertions::const_assert_eq;
 use std::mem;
 use ultraviolet::Vec3;
 
 #[allow(dead_code)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 #[repr(u8)] // Oganesson == 118
 pub enum Element {
     Hydrogen = 1,

--- a/crates/scene/Cargo.toml
+++ b/crates/scene/Cargo.toml
@@ -10,7 +10,10 @@ render = { workspace = true }
 periodic-table = { workspace = true }
 ultraviolet = { workspace = true }
 common = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 petgraph = "0.6.3"
 indexmap = "1.6"
 once_cell = "1.18.0"
 lazy_static = "1.4.0"
+lib3dmol = "0.4"

--- a/crates/scene/src/assembly.rs
+++ b/crates/scene/src/assembly.rs
@@ -74,8 +74,10 @@ impl Assembly {
                 let new_transform = component.transform * acc_transform;
                 match &component.data {
                     ComponentType::Molecule(molecule) => {
-                        molecules.push(molecule.atoms());
-                        transforms.push(new_transform);
+                        if let Some(atoms) = molecule.repr.atoms() {
+                            molecules.push(atoms);
+                            transforms.push(new_transform);
+                        }
                     }
                     ComponentType::SubAssembly(sub_assembly) => {
                         stack.push((sub_assembly, new_transform));
@@ -92,7 +94,7 @@ impl Assembly {
         for component in self.components.iter_mut() {
             match &mut component.data {
                 ComponentType::Molecule(ref mut molecule) => {
-                    molecule.reupload_atoms(gpu_resources);
+                    molecule.repr.reupload_atoms(gpu_resources);
                 }
                 ComponentType::SubAssembly(ref mut assembly) => {
                     assembly.synchronize_buffers(gpu_resources);

--- a/crates/scene/src/feature.rs
+++ b/crates/scene/src/feature.rs
@@ -39,19 +39,19 @@ pub trait MoleculeCommands {
     ) -> Result<(), FeatureError>;
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BondedAtom {
     pub target: AtomSpecifier,
     pub element: Element,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PdbFeature {
     pub name: String,
     pub contents: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum Feature {
     RootAtom(Element),
     BondedAtom(BondedAtom),

--- a/crates/scene/src/feature.rs
+++ b/crates/scene/src/feature.rs
@@ -1,10 +1,10 @@
-use std::{borrow::Borrow, collections::HashMap};
+use std::collections::HashMap;
 
 use periodic_table::Element;
 
 use crate::{ids::*, molecule::AtomNode, BondOrder};
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub enum ReferenceType {

--- a/crates/scene/src/ids.rs
+++ b/crates/scene/src/ids.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 pub type FeatureId = usize;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct FeatureCopyId {
     pub feature_id: FeatureId,
     pub copy_index: usize,
@@ -39,7 +41,7 @@ pub struct FeatureCopyId {
 /// atom is a mirrored copy of a mirrored copy of some primitive, it's feature path will include
 /// all of those features). Trivially, this is useful for figuring out where an atom comes from,
 /// but it is less obvious that edge cases with repeated patterning arise if it is not included.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct AtomSpecifier {
     pub feature_path: Vec<FeatureCopyId>,
     pub child_index: usize,

--- a/crates/scene/src/lib.rs
+++ b/crates/scene/src/lib.rs
@@ -6,5 +6,6 @@ mod assembly;
 pub mod feature;
 pub mod ids;
 mod molecule;
+mod pdb;
 mod utils;
 mod vsepr;

--- a/crates/scene/src/molecule.rs
+++ b/crates/scene/src/molecule.rs
@@ -311,12 +311,11 @@ impl<'de> Deserialize<'de> for Molecule {
         // TODO: integrity check of the deserialized struct
 
         let raw_molecule = RawMolecule::deserialize(deserializer)?;
-        let mut repr = MoleculeRepr::default();
 
         let mut molecule = Molecule {
-            repr,
-            rotation: ultraviolet::Rotor3::default(),
-            offset: ultraviolet::Vec3::default(),
+            repr: MoleculeRepr::default(),
+            rotation: raw_molecule.rotation,
+            offset: raw_molecule.offset,
             features: raw_molecule.features,
             history_step: 0, // This starts at 0 because we haven't applied the features, we've just loaded them
         };

--- a/crates/scene/src/molecule.rs
+++ b/crates/scene/src/molecule.rs
@@ -155,10 +155,7 @@ pub struct Molecule {
 }
 
 impl Molecule {
-    pub fn from_feature(
-        gpu_resources: &GlobalRenderResources,
-        feature: impl Feature + 'static,
-    ) -> Self {
+    pub fn from_feature(gpu_resources: &GlobalRenderResources, feature: Feature) -> Self {
         let mut repr = MoleculeRepr::default();
         feature
             .apply(&0, &mut repr)
@@ -181,7 +178,7 @@ impl Molecule {
         &self.features
     }
 
-    pub fn push_feature(&mut self, feature: impl Feature + 'static) {
+    pub fn push_feature(&mut self, feature: Feature) {
         self.features.insert(feature, self.history_step);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ use scene::{
     Assembly, Component, Molecule,
 };
 
-use serde_json;
 use std::rc::Rc;
 use ultraviolet::{Mat4, Vec3};
 use winit::{
@@ -85,6 +84,7 @@ fn make_pdb_demo_scene(gpu_resources: &GlobalRenderResources) -> Molecule {
     molecule
 }
 
+#[allow(dead_code)]
 fn make_salt_demo_scene(gpu_resources: &GlobalRenderResources) -> Molecule {
     let mut molecule = Molecule::from_feature(Feature::RootAtom(periodic_table::Element::Sodium));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,6 @@ pub mod camera;
 /// A platform-independent abstraction over the windowing system's interface
 /// for menus and menubars.  Used to setup the application menubar on startup.
 pub mod menubar;
-/// A module for loading and parsing PDB files.
-///
-/// TODO: Should probably be abstracted into its own crate.
-pub mod pdb;
 
 // This module is not public.  It is a common abstraction over the various
 // platform-specific APIs.  For example, `platform::menubar` exposes an API
@@ -62,9 +58,11 @@ pub const APP_NAME: &str = "atomCAD";
 
 use camera::ArcballCamera;
 use common::InputEvent;
-use pdb::PdbFeature;
 use render::{GlobalRenderResources, Interactions, RenderOptions, Renderer};
-use scene::{Assembly, Component, Molecule};
+use scene::{
+    feature::{Feature, PdbFeature},
+    Assembly, Component, Molecule,
+};
 
 use std::rc::Rc;
 use ultraviolet::{Mat4, Vec3};
@@ -90,10 +88,10 @@ async fn resume_renderer(
 
     let molecule = Molecule::from_feature(
         &gpu_resources,
-        PdbFeature {
+        Feature::PdbFeature(PdbFeature {
             name: "Neon Pump".into(),
             contents: include_str!("../assets/neon_pump_imm.pdb").into(),
-        },
+        }),
     );
 
     let assembly = Assembly::from_components([Component::from_molecule(molecule, Mat4::default())]);


### PR DESCRIPTION
Re. #23, I've implemented basic serialization and deserialization to the `Molecule` struct.

There are two important things to note about this PR:
- The feature system has been refactored to avoid the need to deserialize `FeatureList's` `Vec<dyn Feature>`
- Right now the serialization process discards atom coordinates, and deserialization computes them using features alone. This is because we currently do not compute energy minimizing geometry corrections, so the atom coordinates are still a cheap-to-compute pure function of the featurelist.
- As part of deserialization, I needed to refactor the GPU synchronization that molecules do. It is now much cleaner (for example, you don't need a handle to `GlobalGpuResources` in order to create a molecule. This also allows us to create zero-atom `Molecule`s, which was previously impossible - this sounds useless but will actually make our code simpler in many places (i.e. the first feature no longer needs special treatment in `set_history_step`)

When I make a PR to introduce energy minimizing geometry corrections, I will update molecule to serialize them.

Happy to make any changes needed before this gets merged :)