### PR TITLE
Bond Rendering

### DIFF
--- a/crates/molecule/src/molecule.rs
+++ b/crates/molecule/src/molecule.rs
@@ -7,10 +7,7 @@ use std::collections::HashMap;
 use common::{ids::AtomSpecifier, BoundingBox};
 use lazy_static::lazy_static;
 use periodic_table::Element;
-use petgraph::{
-    stable_graph,
-    visit::{IntoEdgeReferences, IntoNodeReferences},
-};
+use petgraph::{stable_graph, visit::IntoNodeReferences};
 use render::{AtomBuffer, AtomKind, AtomRepr, BondBuffer, BondRepr, GlobalRenderResources};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;

--- a/crates/render/src/bond_buffer.rs
+++ b/crates/render/src/bond_buffer.rs
@@ -54,7 +54,7 @@ impl BondBuffer {
         for bond in bonds {
             bond_a1.extend(&(bond.atom_1).to_ne_bytes());
             bond_a2.extend(&(bond.atom_2).to_ne_bytes());
-            bond_order.extend(&(bond.order as u8).to_ne_bytes());
+            bond_order.extend(&(bond.order).to_ne_bytes());
         }
 
         bond_a1.resize(bond_a1.capacity(), 0);

--- a/crates/render/src/bond_buffer.rs
+++ b/crates/render/src/bond_buffer.rs
@@ -1,0 +1,176 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::GlobalRenderResources;
+use common::AsBytes;
+use std::{cmp, mem};
+use ultraviolet::Vec4;
+
+#[derive(Copy, Clone, PartialEq)]
+#[repr(C, align(16))]
+pub struct BondRepr {
+    pub start_pos: Vec4, // In the molecule frame
+    pub end_pos: Vec4,
+    pub order: u32,
+    #[allow(unused)]
+    pub pad: u32,
+}
+
+static_assertions::const_assert_eq!(mem::size_of::<BondRepr>(), 48);
+unsafe impl AsBytes for BondRepr {}
+
+/// Essentially a per-fragment uniform.
+#[repr(C, align(16))]
+#[derive(Default)]
+pub struct BondBufferHeader;
+
+unsafe impl AsBytes for BondBufferHeader {}
+
+pub struct BondBuffer {
+    bind_group: wgpu::BindGroup,
+    number_of_bonds: usize,
+}
+
+impl BondBuffer {
+    pub fn new<I>(gpu_resources: &GlobalRenderResources, iter: I) -> Self
+    where
+        I: IntoIterator<Item = BondRepr>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let bonds = iter.into_iter();
+        let number_of_bonds = bonds.len();
+        assert!(number_of_bonds > 0, "must have at least one bond");
+
+        // Serialize iterator into buffers
+        let texel_count = if number_of_bonds <= 2048 {
+            cmp::max(1, number_of_bonds)
+        } else {
+            (number_of_bonds + 2047) & !2047
+        };
+        let mut bond_pos =
+            Vec::with_capacity((texel_count * 4 * mem::size_of::<f32>() + 255) & !255);
+        let mut bond_kind = Vec::with_capacity((texel_count * mem::size_of::<u8>() + 255) & !255);
+        for bond in bonds {
+            bond_pos.extend_from_slice(bond.pos.as_bytes());
+            bond_pos.extend_from_slice(&[0; 4]); // padding
+            bond_kind.extend(&(bond.kind.0 as u8).to_ne_bytes());
+        }
+        bond_pos.resize(bond_pos.capacity(), 0);
+        bond_kind.resize(bond_kind.capacity(), 0);
+
+        assert_eq!(
+            bond_pos.len() % 256,
+            0,
+            "texture row must be a multiple of 256 bytes"
+        );
+        assert_eq!(
+            bond_kind.len() % 256,
+            0,
+            "texture row must be a multiple of 256 bytes"
+        );
+
+        let size = wgpu::Extent3d {
+            width: cmp::min(texel_count, 2048) as u32,
+            height: ((texel_count + 2047) / 2048) as u32,
+            depth_or_array_layers: 1,
+        };
+
+        let pos_texture = gpu_resources
+            .device
+            .create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                size,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba32Float,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            });
+
+        gpu_resources.queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &pos_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &bond_pos,
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(size.width * 4 * mem::size_of::<f32>() as u32),
+                rows_per_image: Some(size.height),
+            },
+            size,
+        );
+
+        let kind_texture = gpu_resources
+            .device
+            .create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                size,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::R8Uint,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            });
+
+        gpu_resources.queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &kind_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &bond_kind,
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(size.width * mem::size_of::<u8>() as u32),
+                rows_per_image: Some(size.height),
+            },
+            size,
+        );
+
+        let pos_texture_view = pos_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let kind_texture_view = kind_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let bind_group = gpu_resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &gpu_resources.bond_bgl,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&pos_texture_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::TextureView(&kind_texture_view),
+                    },
+                ],
+            });
+
+        Self {
+            bind_group,
+            number_of_bonds,
+        }
+    }
+
+    pub fn bind_group(&self) -> &wgpu::BindGroup {
+        &self.bind_group
+    }
+
+    pub fn len(&self) -> usize {
+        self.number_of_bonds
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+// End of File

--- a/crates/render/src/bond_buffer.rs
+++ b/crates/render/src/bond_buffer.rs
@@ -5,19 +5,16 @@
 use crate::GlobalRenderResources;
 use common::AsBytes;
 use std::{cmp, mem};
-use ultraviolet::Vec4;
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C, align(16))]
 pub struct BondRepr {
-    pub start_pos: Vec4, // In the molecule frame
-    pub end_pos: Vec4,
-    pub order: u32,
-    #[allow(unused)]
-    pub pad: u32,
+    pub atom_1: u32,
+    pub atom_2: u32,
+    pub order: u8,
 }
 
-static_assertions::const_assert_eq!(mem::size_of::<BondRepr>(), 48);
+static_assertions::const_assert_eq!(mem::size_of::<BondRepr>(), 16);
 unsafe impl AsBytes for BondRepr {}
 
 /// Essentially a per-fragment uniform.
@@ -48,24 +45,34 @@ impl BondBuffer {
         } else {
             (number_of_bonds + 2047) & !2047
         };
-        let mut bond_pos =
-            Vec::with_capacity((texel_count * 4 * mem::size_of::<f32>() + 255) & !255);
-        let mut bond_kind = Vec::with_capacity((texel_count * mem::size_of::<u8>() + 255) & !255);
+
+        let capacity = (texel_count * 4 * mem::size_of::<f32>() + 255) & !255;
+        let mut bond_a1 = Vec::with_capacity(capacity);
+        let mut bond_a2 = Vec::with_capacity(capacity);
+        let mut bond_order = Vec::with_capacity(capacity);
+
         for bond in bonds {
-            bond_pos.extend_from_slice(bond.pos.as_bytes());
-            bond_pos.extend_from_slice(&[0; 4]); // padding
-            bond_kind.extend(&(bond.kind.0 as u8).to_ne_bytes());
+            bond_a1.extend(&(bond.atom_1).to_ne_bytes());
+            bond_a2.extend(&(bond.atom_2).to_ne_bytes());
+            bond_order.extend(&(bond.order as u8).to_ne_bytes());
         }
-        bond_pos.resize(bond_pos.capacity(), 0);
-        bond_kind.resize(bond_kind.capacity(), 0);
+
+        bond_a1.resize(bond_a1.capacity(), 0);
+        bond_a2.resize(bond_a2.capacity(), 0);
+        bond_order.resize(bond_order.capacity(), 0);
 
         assert_eq!(
-            bond_pos.len() % 256,
+            bond_a1.len() % 256,
             0,
             "texture row must be a multiple of 256 bytes"
         );
         assert_eq!(
-            bond_kind.len() % 256,
+            bond_a2.len() % 256,
+            0,
+            "texture row must be a multiple of 256 bytes"
+        );
+        assert_eq!(
+            bond_order.len() % 256,
             0,
             "texture row must be a multiple of 256 bytes"
         );
@@ -76,36 +83,26 @@ impl BondBuffer {
             depth_or_array_layers: 1,
         };
 
-        let pos_texture = gpu_resources
-            .device
-            .create_texture(&wgpu::TextureDescriptor {
-                label: None,
-                size,
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: wgpu::TextureFormat::Rgba32Float,
-                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-                view_formats: &[],
-            });
-
-        gpu_resources.queue.write_texture(
-            wgpu::ImageCopyTexture {
-                texture: &pos_texture,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            &bond_pos,
-            wgpu::ImageDataLayout {
-                offset: 0,
-                bytes_per_row: Some(size.width * 4 * mem::size_of::<f32>() as u32),
-                rows_per_image: Some(size.height),
-            },
+        let index_texture_descriptor = wgpu::TextureDescriptor {
+            label: None,
             size,
-        );
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::R32Uint,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        };
 
-        let kind_texture = gpu_resources
+        let bond_a1_texture = gpu_resources
+            .device
+            .create_texture(&index_texture_descriptor);
+        let bond_a2_texture = gpu_resources
+            .device
+            .create_texture(&index_texture_descriptor);
+
+        // The bond order is only a u8 so we give it a different descriptor
+        let bond_order_texture = gpu_resources
             .device
             .create_texture(&wgpu::TextureDescriptor {
                 label: None,
@@ -118,24 +115,54 @@ impl BondBuffer {
                 view_formats: &[],
             });
 
+        let data_layout = wgpu::ImageDataLayout {
+            offset: 0,
+            bytes_per_row: Some(size.width * 4 * mem::size_of::<f32>() as u32),
+            rows_per_image: Some(size.height),
+        };
+
         gpu_resources.queue.write_texture(
             wgpu::ImageCopyTexture {
-                texture: &kind_texture,
+                texture: &bond_a1_texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            &bond_kind,
-            wgpu::ImageDataLayout {
-                offset: 0,
-                bytes_per_row: Some(size.width * mem::size_of::<u8>() as u32),
-                rows_per_image: Some(size.height),
-            },
+            &bond_a1,
+            data_layout,
             size,
         );
 
-        let pos_texture_view = pos_texture.create_view(&wgpu::TextureViewDescriptor::default());
-        let kind_texture_view = kind_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        gpu_resources.queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &bond_a2_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &bond_a2,
+            data_layout,
+            size,
+        );
+
+        gpu_resources.queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &bond_order_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &bond_order,
+            data_layout,
+            size,
+        );
+
+        let bond_a1_texture_view =
+            bond_a1_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let bond_a2_texture_view =
+            bond_a2_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let bond_order_texture_view =
+            bond_order_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         let bind_group = gpu_resources
             .device
@@ -145,11 +172,15 @@ impl BondBuffer {
                 entries: &[
                     wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::TextureView(&pos_texture_view),
+                        resource: wgpu::BindingResource::TextureView(&bond_a1_texture_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 1,
-                        resource: wgpu::BindingResource::TextureView(&kind_texture_view),
+                        resource: wgpu::BindingResource::TextureView(&bond_a2_texture_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::TextureView(&bond_order_texture_view),
                     },
                 ],
             });

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -16,6 +16,7 @@ use winit::{dpi::PhysicalSize, window::Window};
 
 mod atom_buffer;
 mod bind_groups;
+mod bond_buffer;
 mod buffer_vec;
 mod camera;
 mod passes;

--- a/crates/render/src/passes/bond.wgsl
+++ b/crates/render/src/passes/bond.wgsl
@@ -192,8 +192,12 @@ struct BondFragmentOutput {
 
 @fragment
 fn fs_main(in: BondFragmentInput) -> BondFragmentOutput {
-    let z = sqrt(bar_width * bar_width - in.uv.y * in.uv.y);
-    let in_pos_clipspace = in.position_clip_space + camera.projection[2] * z;
+    // This adds curvature, but we don't really want it because the bond floats
+    // in space between the atoms. So only when the atons happen to lie in a plane
+    // parallel to the screen will this render properly
+    // let z = sqrt(bar_width * bar_width - in.uv.y * in.uv.y);
+    // let in_pos_clipspace = in.position_clip_space + camera.projection[2] * z;
+    let in_pos_clipspace = in.position_clip_space;
     let depth = in_pos_clipspace.z / in_pos_clipspace.w;
 
     let normal = vec4(normalize(in.position_view_space.xyz - in.center_view_space.xyz), 0.0);

--- a/crates/render/src/passes/bond.wgsl
+++ b/crates/render/src/passes/bond.wgsl
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This shader uses an interesting technique that is sometimes called
+// progrmamable vertex pulling.
+//
+// Instead of providing a vertex buffer, we instead provide an array of points
+// in a storage buffer and then call draw with <number of points> * 6
+//
+// This is apparently faster than instancing for small meshes.
+//
+// See slide 20 of
+// https://www.slideshare.net/DevCentralAMD/vertex-shader-tricks-bill-bilodeau.
+
+struct Camera {
+    projection: mat4x4<f32>,
+    view: mat4x4<f32>,
+    projection_view: mat4x4<f32>,
+};
+
+struct Vertex {
+    xy: vec2<f32>,
+    padding: vec2<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> camera: Camera;
+
+struct Atom {
+    pos: vec3<f32>,
+    kind: u32,
+};
+
+struct Bond {
+    start_pos: vec3<f32>,
+    end_pos: vec3<f32>,
+    order: u32,
+};
+
+@group(1) @binding(0)
+var atoms_pos: texture_2d<f32>;
+
+@group(2) @binding(0)
+var bonds_a1: texture_2d<u32>;
+@group(2) @binding(1)
+var bonds_a2: texture_2d<u32>;
+@group(2) @binding(2)
+var bonds_order: texture_2d<u32>;
+
+struct BondVertexInput {
+    @builtin(vertex_index)
+    index: u32,
+    @location(0)
+    part_fragment_transform_0: vec4<f32>,
+    @location(1)
+    part_fragment_transform_1: vec4<f32>,
+    @location(2)
+    part_fragment_transform_2: vec4<f32>,
+    @location(3)
+    part_fragment_transform_3: vec4<f32>,
+};
+
+struct BondVertexOutput {
+    @builtin(position)
+    position: vec4<f32>,
+    @location(0)
+    uv: vec2<f32>,
+    @location(1)
+    position_clip_space: vec4<f32>,
+    @location(2)
+    position_view_space: vec4<f32>,
+    @location(3) @interpolate(flat)
+    center_view_space: vec4<f32>,
+    @location(4) @interpolate(flat)
+    order: u32
+};
+
+const pi = 3.14159265359;
+const bar_width = 0.8;
+
+@vertex
+fn vs_main(in: BondVertexInput) -> BondVertexOutput {
+    let idx = in.index / 6u;
+    let coord = vec2<u32>(idx & 0x000007ffu, idx >> 11u);
+    let a1_index = textureLoad(bonds_a1, coord, 0).x;
+    let a2_index = textureLoad(bonds_a2, coord, 0).x;
+    let bond_order = textureLoad(bonds_order, coord, 0).x;
+
+    let a1_coord = vec2<u32>(a1_index & 0x000007ffu, a1_index >> 11u);
+    let a2_coord = vec2<u32>(a2_index & 0x000007ffu, a2_index >> 11u);
+
+    let a1_pos = textureLoad(atoms_pos, a1_coord, 0).xyz;
+    let a2_pos = textureLoad(atoms_pos, a2_coord, 0).xyz;
+
+    let bond = Bond(a1_pos, a2_pos, bond_order);
+    let part_fragment_transform = mat4x4<f32>(
+        in.part_fragment_transform_0,
+        in.part_fragment_transform_1,
+        in.part_fragment_transform_2,
+        in.part_fragment_transform_3
+    );
+    
+    // Equivalent to:
+    // var angle = pi / 2.0 * (0.5 + f32(in.index % 3u))
+    // if in.index % 6u >= 3u {
+    //     angle += pi;
+    // }
+    let angle = pi * ((0.5 + f32(in.index % 3u)) / 2.0 + f32((in.index % 6u) / 3u));
+    let start_pos = (camera.view * part_fragment_transform * vec4<f32>(bond.start_pos.xyz, 1.0)).xy;
+    let end_pos = (camera.view * part_fragment_transform * vec4<f32>(bond.end_pos.xyz, 1.0)).xy;
+    let displacement = start_pos - end_pos;
+    let length = length(displacement);
+    let screen_angle = atan2(displacement.y, displacement.x);
+
+    let uv = vec2(sign(cos(angle)) + 1.0, sign(sin(angle)) + 1.0) / 2.0;
+    // make a rectangle - this looks like a weird use of sin and cos but we care about the
+    // end-to-end length, not the length of the diagonal! This is the axis-aligned rectangle
+    let aa_vertex = vec2(0.5 * length * sign(cos(angle)), 0.5 * bar_width * sign(sin(angle)));
+    // Now we rotate it to the correct angle (this is a rotation matrix in longform)
+    var vertex = aa_vertex;
+    let csa = cos(screen_angle);
+    let ssa = sin(screen_angle);
+    vertex.x = csa * aa_vertex.x - ssa * aa_vertex.y;
+    vertex.y = ssa * aa_vertex.x + csa * aa_vertex.y;
+    
+    let pos = (bond.start_pos + bond.end_pos).xyz / 2.0;
+    let position = part_fragment_transform * vec4<f32>(pos, 1.0);
+
+    let camera_right_worldspace = vec3<f32>(camera.view[0][0], camera.view[1][0], camera.view[2][0]);
+    let camera_up_worldspace = vec3<f32>(camera.view[0][1], camera.view[1][1], camera.view[2][1]);
+    let position_worldspace = vec4<f32>(
+        position.xyz +
+        vertex.x * camera_right_worldspace +
+        vertex.y * camera_up_worldspace,
+        1.0
+    );
+
+    let position_clip_space = camera.projection_view * position_worldspace;
+    let center_view_space = camera.view * vec4<f32>(pos, 0.0);
+    let position_view_space = camera.view * position_worldspace;
+
+    return BondVertexOutput(position_clip_space, uv, position_clip_space, position_view_space, center_view_space, bond.order);
+}
+
+alias BondFragmentInput = BondVertexOutput;
+
+struct BondFragmentOutput {
+    @builtin(frag_depth)
+    depth: f32,
+    @location(0)
+    color: vec4<f32>,
+    @location(1)
+    normal: vec4<f32>,
+}
+
+@fragment
+fn fs_main(in: BondFragmentInput) -> BondFragmentOutput {
+    let z = sqrt(bar_width * bar_width - in.uv.y * in.uv.y);
+    let in_pos_clipspace = in.position_clip_space + camera.projection[2] * z;
+    let depth = in_pos_clipspace.z / in_pos_clipspace.w;
+
+    let normal = vec4(normalize(in.position_view_space.xyz - in.center_view_space.xyz), 0.0);
+    let color = vec3(1.0, 1.0, 1.0);
+    let brightness = sin(in.uv.y * pi * (2.0 * f32(in.order) - 1.0));
+
+    if brightness < 0.0 {
+        discard;
+    }
+
+    return BondFragmentOutput(depth, vec4(color * brightness, 1.0), normal);
+}

--- a/crates/render/src/passes/molecular.rs
+++ b/crates/render/src/passes/molecular.rs
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{AtomBuffer, GlobalRenderResources, Renderer, SWAPCHAIN_FORMAT};
+use crate::{AtomBuffer, BondBuffer, GlobalRenderResources, Renderer, SWAPCHAIN_FORMAT};
 use std::{convert::TryInto as _, mem};
 use winit::dpi::PhysicalSize;
 
 // Renders atoms
 pub struct MolecularPass {
-    pipeline: wgpu::RenderPipeline,
+    atom_pipeline: wgpu::RenderPipeline,
+    bond_pipeline: wgpu::RenderPipeline,
     top_level_bg: wgpu::BindGroup,
 
     color_texture: wgpu::TextureView,
@@ -49,10 +50,16 @@ impl MolecularPass {
         size: PhysicalSize<u32>,
     ) -> (Self, wgpu::TextureView) {
         let top_level_bgl = create_top_level_bgl(&render_resources.device);
-        let pipeline = create_render_pipeline(
+        let atom_pipeline = create_atom_render_pipeline(
             &render_resources.device,
             &top_level_bgl,
             &render_resources.atom_bgl,
+        );
+        let bond_pipeline = create_bond_render_pipeline(
+            &render_resources.device,
+            &top_level_bgl,
+            &render_resources.atom_bgl,
+            &render_resources.bond_bgl,
         );
         let top_level_bg = create_top_level_bg(
             &render_resources.device,
@@ -68,7 +75,8 @@ impl MolecularPass {
 
         (
             Self {
-                pipeline,
+                atom_pipeline,
+                bond_pipeline,
                 top_level_bg,
 
                 color_texture: color_texture.create_view(&wgpu::TextureViewDescriptor::default()),
@@ -98,12 +106,17 @@ impl MolecularPass {
     pub fn run<'a>(
         &self,
         encoder: &mut wgpu::CommandEncoder,
-        atoms: impl IntoIterator<Item = &'a AtomBuffer>,
+        atoms: &[&'a AtomBuffer],
+        bonds: &[Option<&'a BondBuffer>],
         fragment_transforms: &wgpu::Buffer,
         // fragments: impl IntoIterator<Item = &'a Fragment>,
         // fragment_transforms: &wgpu::Buffer,
         // per_fragment: &HashMap<FragmentId, (PartId, u64 /* transform index */)>,
     ) {
+        assert!(
+            atoms.len() == bonds.len(),
+            "Must have equal number of AtomBuffers and Option<BondBuffers>"
+        );
         let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: None,
             color_attachments: &[
@@ -141,7 +154,7 @@ impl MolecularPass {
             }),
         });
 
-        rpass.set_pipeline(&self.pipeline);
+        rpass.set_pipeline(&self.atom_pipeline);
         rpass.set_bind_group(0, &self.top_level_bg, &[]);
 
         for (idx, atoms_inst) in atoms.into_iter().enumerate() {
@@ -156,6 +169,29 @@ impl MolecularPass {
 
             rpass.set_bind_group(1, atoms_inst.bind_group(), &[]);
             rpass.draw(0..(atoms_inst.len() * 3).try_into().unwrap(), 0..1);
+        }
+
+        // render bonds
+        rpass.set_pipeline(&self.bond_pipeline);
+        rpass.set_bind_group(0, &self.top_level_bg, &[]);
+
+        for (idx, bonds_inst) in bonds.into_iter().enumerate() {
+            if let Some(bonds_inst) = bonds_inst {
+                let transform_offset = (idx * mem::size_of::<ultraviolet::Mat4>()) as u64;
+
+                rpass.set_vertex_buffer(
+                    0,
+                    fragment_transforms.slice(
+                        transform_offset
+                            ..transform_offset + mem::size_of::<ultraviolet::Mat4>() as u64,
+                    ),
+                );
+
+                rpass.set_bind_group(1, atoms[idx].bind_group(), &[]);
+                rpass.set_bind_group(2, bonds_inst.bind_group(), &[]);
+                // the factor of 6 is used because each atom becomes a quad (two tris)
+                rpass.draw(0..(bonds_inst.len() * 6).try_into().unwrap(), 0..1);
+            }
         }
     }
 }
@@ -239,7 +275,7 @@ fn create_top_level_bg(
     })
 }
 
-fn create_render_pipeline(
+fn create_atom_render_pipeline(
     device: &wgpu::Device,
     top_level_bgl: &wgpu::BindGroupLayout,
     atom_bgl: &wgpu::BindGroupLayout,
@@ -283,6 +319,71 @@ fn create_render_pipeline(
             strip_index_format: None,
             front_face: wgpu::FrontFace::Ccw,
             cull_mode: Some(wgpu::Face::Front),
+            unclipped_depth: false,
+            polygon_mode: wgpu::PolygonMode::Fill,
+            conservative: false,
+        },
+        depth_stencil: Some(wgpu::DepthStencilState {
+            format: wgpu::TextureFormat::Depth32Float,
+            depth_write_enabled: true,
+            depth_compare: wgpu::CompareFunction::Greater,
+            stencil: wgpu::StencilState::default(),
+            bias: wgpu::DepthBiasState::default(),
+        }),
+        multisample: wgpu::MultisampleState {
+            count: 1,
+            mask: !0,
+            alpha_to_coverage_enabled: false,
+        },
+        multiview: None,
+    })
+}
+
+fn create_bond_render_pipeline(
+    device: &wgpu::Device,
+    top_level_bgl: &wgpu::BindGroupLayout,
+    atom_bgl: &wgpu::BindGroupLayout,
+    bond_bgl: &wgpu::BindGroupLayout,
+) -> wgpu::RenderPipeline {
+    let bond_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: None,
+        bind_group_layouts: &[top_level_bgl, atom_bgl, bond_bgl],
+        push_constant_ranges: &[],
+    });
+
+    let bond_shader = device.create_shader_module(wgpu::include_wgsl!("bond.wgsl"));
+
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: None,
+        layout: Some(&bond_pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &bond_shader,
+            entry_point: "vs_main",
+            buffers: &[wgpu::VertexBufferLayout {
+                array_stride: mem::size_of::<ultraviolet::Mat4>() as _,
+                step_mode: wgpu::VertexStepMode::Instance,
+                attributes: &wgpu::vertex_attr_array![
+                    // part and fragment transform matrix
+                    0 => Float32x4,
+                    1 => Float32x4,
+                    2 => Float32x4,
+                    3 => Float32x4,
+                ],
+            }],
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &bond_shader,
+            entry_point: "fs_main",
+            targets: &[
+                Some(SWAPCHAIN_FORMAT.into()),
+                Some(wgpu::TextureFormat::Rgba16Float.into()),
+            ],
+        }),
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: wgpu::FrontFace::Ccw,
+            cull_mode: None,
             unclipped_depth: false,
             polygon_mode: wgpu::PolygonMode::Fill,
             conservative: false,

--- a/crates/render/src/passes/molecular.rs
+++ b/crates/render/src/passes/molecular.rs
@@ -157,7 +157,7 @@ impl MolecularPass {
         rpass.set_pipeline(&self.atom_pipeline);
         rpass.set_bind_group(0, &self.top_level_bg, &[]);
 
-        for (idx, atoms_inst) in atoms.into_iter().enumerate() {
+        for (idx, atoms_inst) in atoms.iter().enumerate() {
             let transform_offset = (idx * mem::size_of::<ultraviolet::Mat4>()) as u64;
 
             rpass.set_vertex_buffer(
@@ -175,7 +175,7 @@ impl MolecularPass {
         rpass.set_pipeline(&self.bond_pipeline);
         rpass.set_bind_group(0, &self.top_level_bg, &[]);
 
-        for (idx, bonds_inst) in bonds.into_iter().enumerate() {
+        for (idx, bonds_inst) in bonds.iter().enumerate() {
             if let Some(bonds_inst) = bonds_inst {
                 let transform_offset = (idx * mem::size_of::<ultraviolet::Mat4>()) as u64;
 

--- a/crates/scene/src/assembly.rs
+++ b/crates/scene/src/assembly.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use molecule::MoleculeEditor;
-use render::AtomBuffer;
+use render::{AtomBuffer, BondBuffer};
 use ultraviolet::Mat4;
 
 enum ComponentType {
@@ -62,12 +62,15 @@ impl Assembly {
         }
     }
 
-    pub fn collect_atoms_and_transforms(&self) -> (Vec<&AtomBuffer>, Vec<Mat4>) {
+    pub fn collect_rendering_primitives(
+        &self,
+    ) -> (Vec<&AtomBuffer>, Vec<Option<&BondBuffer>>, Vec<Mat4>) {
         // The number of direct children of the world is an estimate of the
         // lower bound of the number of molecules. It is only possible for this to
         // overestimate if a child assembly contains zero children (which is unusual).
         let mut transforms = Vec::<Mat4>::with_capacity(self.components.len());
-        let mut molecules = Vec::<&AtomBuffer>::with_capacity(self.components.len());
+        let mut atom_buffers = Vec::<&AtomBuffer>::with_capacity(self.components.len());
+        let mut bond_buffers = Vec::<Option<&BondBuffer>>::with_capacity(self.components.len());
 
         // DFS
         let mut stack: Vec<(&Assembly, Mat4)> = vec![(self, Mat4::default())];
@@ -76,9 +79,10 @@ impl Assembly {
             for component in &assembly.components {
                 let new_transform = component.transform * acc_transform;
                 match &component.data {
-                    ComponentType::Molecule(molecule) => {
-                        if let Some(atoms) = molecule.repr.atoms() {
-                            molecules.push(atoms);
+                    ComponentType::Molecule(editor) => {
+                        if let Some(atom_buf) = editor.repr.atoms() {
+                            atom_buffers.push(atom_buf);
+                            bond_buffers.push(editor.repr.bonds());
                             transforms.push(new_transform);
                         }
                     }
@@ -89,15 +93,15 @@ impl Assembly {
             }
         }
 
-        (molecules, transforms)
+        (atom_buffers, bond_buffers, transforms)
     }
 
     /// Recursively synchronize the atom data of each molecule to the GPU.
     pub fn synchronize_buffers(&mut self, gpu_resources: &render::GlobalRenderResources) {
         for component in self.components.iter_mut() {
             match &mut component.data {
-                ComponentType::Molecule(ref mut molecule) => {
-                    molecule.repr.reupload_atoms(gpu_resources);
+                ComponentType::Molecule(ref mut editor) => {
+                    editor.repr.synchronize_buffers(gpu_resources);
                 }
                 ComponentType::SubAssembly(ref mut assembly) => {
                     assembly.synchronize_buffers(gpu_resources);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ async fn resume_renderer(
     )
     .await;
 
-    let molecule = make_pdb_demo_scene();
+    let molecule = make_salt_demo_scene();
 
     let assembly = Assembly::from_components([Component::from_molecule(molecule, Mat4::default())]);
     let interactions = Interactions::default();
@@ -173,8 +173,8 @@ fn handle_event(
                             if let Some(gpu_resources) = gpu_resources {
                                 world.synchronize_buffers(gpu_resources);
                             }
-                            let (atoms, transforms) = world.collect_atoms_and_transforms();
-                            renderer.render(atoms, transforms);
+                            let (atoms, bonds, transforms) = world.collect_rendering_primitives();
+                            renderer.render(&atoms, &bonds, transforms);
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ async fn resume_renderer(
     )
     .await;
 
-    let molecule = make_salt_demo_scene();
+    let molecule = make_pdb_demo_scene();
 
     let assembly = Assembly::from_components([Component::from_molecule(molecule, Mat4::default())]);
     let interactions = Interactions::default();


### PR DESCRIPTION
A week ago I implemented bond rendering in https://github.com/shinzlet/atomCAD/tree/bond_render - however, since then, significant changes have been made to our rendering architecture (and the git history got a bit garbled thanks to merging/rebasing on my multiple previous PRs). Rather than try to rebase off of main (which would basically mean a full rewrite of bond rendering anyway), I just cut and pasted it together in our new texture-based pipeline. I mention this just to explain the large diffs in a few of my commits.

This includes a much cleaner implementation of bond rendering that accesses positions from the `AtomBuffer`, rather than duplicating positions in the `BondBuffer` directly. This means the vram footprint is only a fraction of what it was before. Additionally, I added documentation to the bond shader, which previously was messy scratch work.

<img width="791" alt="A simple bond rendering demonstration" src="https://github.com/atomCAD/atomCAD/assets/25427939/889e5a76-51f2-4d37-819d-833fec745d3f">
