### PR TITLE
Remove bevy_infite_grid dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ bevy_egui = { version = "0.21", default-features = false, features = [
     "open_url",
     "default_fonts"
 ] }
-bevy_infinite_grid = { version = "0.8" }
 bevy_mod_picking = { workspace = true }
 common = { workspace = true }
 molecule = { workspace = true }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -8,7 +8,6 @@ use bevy::{
     core_pipeline::{bloom::BloomSettings, tonemapping::Tonemapping},
     prelude::*,
 };
-use bevy_infinite_grid::{InfiniteGridBundle, InfiniteGridPlugin};
 use bevy_mod_picking::prelude::*;
 use molecule::{init_molecule, molecule_builder};
 
@@ -18,7 +17,7 @@ pub struct ScenePlugin;
 /// Scene logic is only active during the State `AppState::Active`
 impl Plugin for ScenePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((CameraPlugin, DefaultPickingPlugins, InfiniteGridPlugin))
+        app.add_plugins((CameraPlugin, DefaultPickingPlugins))
             .add_systems(OnEnter(AppState::Active), setup_molecular_view)
             .add_systems(OnEnter(AppState::Active), init_molecule)
             .add_systems(Update, molecule_builder.run_if(in_state(AppState::Active)))
@@ -68,12 +67,6 @@ fn setup_molecular_view(mut commands: Commands) {
             target,
             up,
         ));
-
-    // infinite grid
-    commands.spawn(InfiniteGridBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 0.0),
-        ..default()
-    });
 
     // light source
     commands.spawn((


### PR DESCRIPTION
The bevy_infinite_grid dependency looks like it accomplishes what we want, but it has some weird bugs (e.g. it is not actually an infinite grid) and isn't very configurable.  We're probably going to have to fork it to make significant changes.  As it is the last dependency which does not support Bevy 0.18, we'll drop it for now and consider writing our own.