### PR TITLE
Persist application settings across runs using sqlite3 configuration database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,10 +308,12 @@ dependencies = [
  "bevy_asset_loader",
  "bevy_egui",
  "bevy_mod_picking",
+ "directories",
  "embed-resource",
  "image",
  "objc",
  "rand",
+ "rusqlite",
  "smooth-bevy-cameras",
  "wasm-bindgen-test",
  "web-sys",
@@ -1723,6 +1725,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +1896,18 @@ dependencies = [
  "event-listener 4.0.0",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2184,6 +2219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "hassle-rs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2463,17 @@ dependencies = [
 
 [[package]]
 name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libredox"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
@@ -2426,6 +2481,16 @@ dependencies = [
  "bitflags 2.4.1",
  "libc",
  "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2818,12 +2883,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
 dependencies = [
- "libredox",
+ "libredox 0.0.2",
 ]
 
 [[package]]
@@ -3062,6 +3133,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox 0.0.1",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3209,20 @@ dependencies = [
  "bitflags 2.4.1",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
+dependencies = [
+ "bitflags 2.4.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3649,6 +3745,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,11 @@ bevy_mod_picking = { version = "0.17", default-features = false, features = [
     "selection",
 ] }
 common = { package = "atomcad-common", path = "crates/common" }
+directories = { version = "5" }
 molecule = { package = "atomcad-molecule", path = "crates/molecule" }
 periodic-table = { package = "atomcad-periodic-table", path = "crates/periodic-table" }
 petgraph = { version = "0.6.4" }
+rusqlite = { version = "0.30", features = ["bundled"] }
 serde = { version =  "1.0" }
 static_assertions = { version = "1" }
 ultraviolet = { version = "0.9" }
@@ -77,11 +79,9 @@ bevy_egui = { version = "0.23", default-features = false, features = [
 ] }
 bevy_mod_picking = { workspace = true }
 common = { workspace = true }
-directories = { version = "5" }
 molecule = { workspace = true }
 periodic-table = { workspace = true }
 rand = { version = "0.8.3" }
-rusqlite = { version = "0.30", features = ["bundled"] }
 smooth-bevy-cameras = { version = "0.10" }
 
 # keep the following in sync with Bevy's dependencies
@@ -94,8 +94,18 @@ web-sys = { version = "0.3" }
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3" }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+directories = { workspace = true }
+rusqlite = { workspace = true }
+
 [target.'cfg(target_os = "macos")'.dependencies]
+directories = { workspace = true }
 objc = "0.2.7"
+rusqlite = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+directories = { workspace = true }
+rusqlite = { workspace = true }
 
 [build-dependencies]
 embed-resource = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ directories = { version = "5" }
 molecule = { workspace = true }
 periodic-table = { workspace = true }
 rand = { version = "0.8.3" }
-rusqlite = { version = "0.30" }
+rusqlite = { version = "0.30", features = ["bundled"] }
 smooth-bevy-cameras = { version = "0.10" }
 
 # keep the following in sync with Bevy's dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,9 +77,11 @@ bevy_egui = { version = "0.23", default-features = false, features = [
 ] }
 bevy_mod_picking = { workspace = true }
 common = { workspace = true }
+directories = { version = "5" }
 molecule = { workspace = true }
 periodic-table = { workspace = true }
 rand = { version = "0.8.3" }
+rusqlite = { version = "0.30" }
 smooth-bevy-cameras = { version = "0.10" }
 
 # keep the following in sync with Bevy's dependencies

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,16 +7,21 @@
 
 use atomcad::{platform::bevy::PlatformTweaks, AppPlugin, APP_NAME};
 use bevy::{
+    app::AppExit,
     prelude::*,
     window::{PresentMode, PrimaryWindow, WindowMode, WindowResolution},
     winit::{WinitSettings, WinitWindows},
     DefaultPlugins,
 };
 use bevy_egui::EguiPlugin;
+use directories::ProjectDirs;
 use std::io::Cursor;
 use winit::window::Icon;
 
+#[derive(Resource)]
 struct AppConfig {
+    /// The primary key of the app_config table in the sqlite3 config database.
+    id: i32,
     /// The resolution of the primary window, as reported by windowing system.
     window_resolution: Vec2,
     /// The position of the top-left corner of the primary window, as reported
@@ -29,6 +34,7 @@ struct AppConfig {
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
+            id: 1,
             window_resolution: (-1., -1.).into(),
             window_position: (-1, -1).into(),
             fullscreen: false,
@@ -36,8 +42,198 @@ impl Default for AppConfig {
     }
 }
 
+impl AppConfig {
+    fn load_from_sqlite<P>(path: P) -> Self
+    where
+        P: AsRef<std::path::Path>,
+    {
+        let defaults = Self::default();
+        match || -> rusqlite::Result<AppConfig> {
+            let conn = match rusqlite::Connection::open(&path) {
+                Ok(conn) => conn,
+                Err(err) => {
+                    info!(
+                        "Failed to open SQLite database {}: {}",
+                        path.as_ref().display(),
+                        err
+                    );
+                    return Err(err);
+                }
+            };
+            const SQL: &str = "SELECT * FROM app_config LIMIT 1";
+            let mut stmt = match conn.prepare(SQL) {
+                Ok(stmt) => stmt,
+                Err(err) => {
+                    info!(
+                        "Failed to prepare SQLite statement for app_config: \"{}\", {}",
+                        SQL, err
+                    );
+                    return Err(err);
+                }
+            };
+            let mut rows = match stmt.query(()) {
+                Ok(rows) => rows,
+                Err(err) => {
+                    info!(
+                        "Failed to execute SQLite statement for app_config: \"{}\", {}",
+                        SQL, err
+                    );
+                    return Err(err);
+                }
+            };
+            let Some(row) = rows.next()? else {
+                info!(
+                    "No rows returned from SQLite query for app_config: \"{}\"",
+                    SQL
+                );
+                return Err(rusqlite::Error::QueryReturnedNoRows);
+            };
+            Ok(Self {
+                id: row.get::<_, i32>(0).unwrap_or(defaults.id),
+                window_resolution: (
+                    row.get::<_, f32>(1).unwrap_or(defaults.window_resolution.x),
+                    row.get::<_, f32>(2).unwrap_or(defaults.window_resolution.y),
+                )
+                    .into(),
+                window_position: (
+                    row.get::<_, i32>(3).unwrap_or(defaults.window_position.x),
+                    row.get::<_, i32>(4).unwrap_or(defaults.window_position.y),
+                )
+                    .into(),
+                fullscreen: row.get::<_, bool>(5).unwrap_or(defaults.fullscreen),
+            })
+        }() {
+            Ok(config) => config,
+            Err(err) => {
+                info!("Failed to read AppConfig settings: {}", err);
+                info!("Using default AppConfig settings");
+                defaults
+            }
+        }
+    }
+
+    fn save_to_sqlite<P>(&self, path: P)
+    where
+        P: AsRef<std::path::Path>,
+    {
+        match || -> rusqlite::Result<()> {
+            let conn = rusqlite::Connection::open(path)?;
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS app_config (
+                    id INTEGER PRIMARY KEY,
+                    window_resolution_x REAL,
+                    window_resolution_y REAL,
+                    window_position_x INTEGER,
+                    window_position_y INTEGER,
+                    fullscreen INTEGER
+                )",
+                (),
+            )?;
+            const SQL: &str = "INSERT OR REPLACE INTO app_config (id, window_resolution_x, window_resolution_y, window_position_x, window_position_y, fullscreen) VALUES (?, ?, ?, ?, ?, ?)";
+            let mut stmt = match conn.prepare(SQL) {
+                Ok(stmt) => stmt,
+                Err(err) => {
+                    info!(
+                        "Failed to prepare SQLite statement for app_config: \"{}\", {}",
+                        SQL, err
+                    );
+                    return Err(err);
+                }
+            };
+            let params = rusqlite::params![
+                self.id,
+                self.window_resolution.x,
+                self.window_resolution.y,
+                self.window_position.x,
+                self.window_position.y,
+                self.fullscreen
+            ];
+            match stmt.execute(params) {
+                Ok(_) => (),
+                Err(err) => {
+                    info!(
+                        "Failed to execute SQLite statement for app_config: \"{}\", {}",
+                        SQL, err
+                    );
+                    return Err(err);
+                }
+            };
+            Ok(())
+        }() {
+            Ok(_) => (),
+            Err(err) => {
+                info!("Failed to persist AppConfig settings: {}", err);
+            }
+        };
+    }
+}
+
+fn update_app_config(
+    mut app_config: ResMut<AppConfig>,
+    windows: NonSend<WinitWindows>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+) {
+    let primary_entity = primary_window.single();
+    if let Some(primary) = windows.get_window(primary_entity) {
+        // Record resolution of primary window.
+        let scale_factor = primary.scale_factor() as f32;
+        let window_resolution = primary.inner_size();
+        if window_resolution.width > 0 && window_resolution.height > 0 {
+            app_config.window_resolution = (
+                (window_resolution.width as f32) / scale_factor,
+                (window_resolution.height as f32) / scale_factor,
+            )
+                .into();
+        };
+
+        // Record position of primary window.
+        if let Ok(window_position) = primary.outer_position() {
+            if window_position.x > 0 || window_position.y > 0 {
+                app_config.window_position = (window_position.x, window_position.y).into();
+            }
+        };
+
+        // Record fullscreen state of primary window.
+        app_config.fullscreen = primary.fullscreen().is_some();
+    };
+}
+
+fn save_app_config(app_config: ResMut<AppConfig>, app_exit_events: EventReader<AppExit>) {
+    // Only run when the app is exiting.
+    if app_exit_events.is_empty() {
+        return;
+    }
+
+    // Create config directory if it doesn't exist.
+    let config_dir = if let Some(project_dirs) = ProjectDirs::from("org", "atomcad", "atomCAD") {
+        project_dirs.config_dir().to_owned()
+    } else {
+        std::path::PathBuf::from(".")
+    };
+    if !config_dir.exists() {
+        if let Err(err) = std::fs::create_dir_all(&config_dir) {
+            info!(
+                "Failed to create config directory {}: {}",
+                config_dir.display(),
+                err
+            );
+            info!("AppConfig will not be persisted.");
+            return;
+        }
+    }
+
+    // Save app config to sqlite3 database.
+    app_config.save_to_sqlite(config_dir.join("settings.sqlite3"));
+}
+
 fn main() {
-    let app_config = AppConfig::default();
+    let config_dir = if let Some(project_dirs) = ProjectDirs::from("org", "atomcad", "atomCAD") {
+        project_dirs.config_dir().to_owned()
+    } else {
+        std::path::PathBuf::from(".")
+    };
+    let settings_db = config_dir.join("settings.sqlite3");
+    let app_config = AppConfig::load_from_sqlite(settings_db);
 
     App::new()
         .insert_resource(WinitSettings::game())
@@ -46,7 +242,6 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: APP_NAME.into(),
-                // FIXME: this should be read from a persistent settings file
                 resolution: if app_config.window_resolution.x < 0.
                     || app_config.window_resolution.y < 0.
                 {
@@ -91,6 +286,9 @@ fn main() {
         .add_plugins(EguiPlugin)
         .add_plugins(AppPlugin)
         .add_systems(Startup, set_window_icon)
+        .insert_resource(app_config)
+        .add_systems(Update, update_app_config)
+        .add_systems(Last, save_app_config)
         .run();
 }
 


### PR DESCRIPTION
Like the title says, this PR adds support for persistent settings using a sqlite3 database. There are a number of ways this implementation can probably be improved, such as moving the code into its own Bevy plugin module, reducing some boilerplate code duplication, and creating a consistent internal interface for persisting settings (instead of a one-off thing just for the primary window config).

But perfect is the enemy of good enough, and this PR improves the user experience.