### PR TITLE
Add Trunk.toml to project root

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,0 +1,5 @@
+[build]
+public_url = "/"
+
+[serve]
+port = 8080


### PR DESCRIPTION
This enables IDEs to live preview `dist/index.html` without any extra config (since they usually default to serving the whole repo).

It also allows the template to work as-is on itch.io and any other services that serve the package under some path.