### PR TITLE
Set viewport meta in index.html for better mobile support.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
         <title>atomCAD</title>
         <link data-trunk rel="copy-dir" href="assets"/>
         <link data-trunk rel="copy-dir" href="credits"/>


### PR DESCRIPTION
Mobile browsers default to a width of ~980px to support desktop sites.

`width=device-width` sets the page width to that of the device instead.

`initial-scale=1` ensures the width is updated when the device is rotated.

`user-scalable=no` prevents the default pinch-to-zoom behavior.