### PR TITLE
Use specific workflow images instead of "latest."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,57 +13,57 @@ jobs:
         platform:
           - os_name: Web Assembly w/ WebGPU
             # So we can test on Safari.
-            os: macos-latest
+            os: macos-13
             target: wasm32-unknown-unknown
             rustflags: --cfg=web_sys_unstable_apis
             run_tests: false
           - os_name: Web Assembly w/ WebGL2
-            os: macos-latest
+            os: macos-13
             target: wasm32-unknown-unknown
             run_tests: false
           - os_name: Android ARMv8-A
-            os: ubuntu-latest
+            os: ubuntu-22.04
             target: aarch64-linux-android
             run_tests: true
           - os_name: iOS A7+
-            os: macos-latest
+            os: macos-13
             target: aarch64-apple-ios
             # iOS needs a custom test runner.
             run_tests: false
           - os_name: Android x86_64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             target: x86_64-linux-android
             run_tests: true
           - os_name: macOS Apple Silicon
-            os: macos-latest
+            os: macos-13
             target: aarch64-apple-darwin
             # GitHub Actions' free/open-source tier does not support
             # Apple Silicon yet.
             run_tests: false
           - os_name: macOS Intel
-            os: macos-latest
+            os: macos-13
             target: x86_64-apple-darwin
             run_tests: true
           - os_name: Windows ARMv8-A
-            os: windows-latest
+            os: windows-2022
             target: aarch64-pc-windows-msvc
             # GitHub Actions' free/open-source tier does not support
             # Windows on ARM yet.
             run_tests: false
           - os_name: Windows x86_64
-            os: windows-latest
+            os: windows-2022
             target: x86_64-pc-windows-msvc
             run_tests: true
           - os_name: Linux ARMv8-A
-            os: ubuntu-latest
+            os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             run_tests: true
           - os_name: Linux ARMv7-A
-            os: ubuntu-latest
+            os: ubuntu-22.04
             target: thumbv7neon-unknown-linux-gnueabihf
             run_tests: true
           - os_name: Linux x86_64/amd64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             run_tests: true
         toolchain:
@@ -118,7 +118,7 @@ jobs:
         run: RUSTFLAGS="${{ matrix.platform.rustflags }}" cross clippy --workspace --target ${{ matrix.platform.target }} --all-targets --all-features -- -D warnings
   rustfmt:
     name: Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -129,7 +129,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ubuntu-latest-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
+          key: ubuntu-22.04-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable

--- a/.github/workflows/deploy-page.yaml
+++ b/.github/workflows/deploy-page.yaml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build-web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-android-google-play.yaml
+++ b/.github/workflows/release-android-google-play.yaml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   bundle-sign-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
       - name: Install Dependencies

--- a/.github/workflows/release-ios-testflight.yaml
+++ b/.github/workflows/release-ios-testflight.yaml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   build-for-iOS:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   get-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Get tag
         id: tag
@@ -30,7 +30,7 @@ jobs:
       version: ${{ inputs.version || steps.tag.outputs.tag }}
 
   build-macOS:
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: get-version
     env:
       # macOS 11.0 Big Sur is the first version to support universal binaries
@@ -81,7 +81,7 @@ jobs:
           overwrite: true
 
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: get-version
     env:
       VERSION: ${{needs.get-version.outputs.version}}
@@ -115,7 +115,7 @@ jobs:
           overwrite: true
 
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: get-version
     env:
       VERSION: ${{needs.get-version.outputs.version}}
@@ -167,7 +167,7 @@ jobs:
           overwrite: true
 
   build-web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: get-version
     env:
       VERSION: ${{needs.get-version.outputs.version}}
@@ -210,7 +210,7 @@ jobs:
           overwrite: true
 
   build-for-iOS:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     needs: get-version
     env:
@@ -239,7 +239,7 @@ jobs:
           overwrite: true
 
   build-for-Android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     needs: get-version
     env:


### PR DESCRIPTION
The current workflows use `ubuntu-latest`, `macos-latest`, and `windows-latest`.  Naturally these change as new images are made available by GitHub, and upgrading the base image could cause workflows to fail.  To prevent this from happening, we should lock to specific stable / long-term support images.