### PR TITLE
Fix #247: block dragging frozen atoms via
  transform_selected

### DIFF
--- a/rust/src/structure_designer/nodes/atom_edit/atom_edit_data.rs
+++ b/rust/src/structure_designer/nodes/atom_edit/atom_edit_data.rs
@@ -878,8 +878,14 @@ impl AtomEditData {
         relative: &Transform,
         base_atoms: &[super::operations::BaseAtomPromotionInfo],
     ) {
-        // Transform existing diff atoms
-        let diff_ids: Vec<u32> = self.selection.selected_diff_atoms.iter().copied().collect();
+        // Transform existing diff atoms, skipping frozen ones.
+        let diff_ids: Vec<u32> = self
+            .selection
+            .selected_diff_atoms
+            .iter()
+            .filter(|&&id| !self.frozen_diff_atoms.contains(&id))
+            .copied()
+            .collect();
         for diff_id in diff_ids {
             let new_position = if let Some(atom) = self.diff.get_atom(diff_id) {
                 relative.apply_to_position(&atom.position)

--- a/rust/src/structure_designer/nodes/atom_edit/operations.rs
+++ b/rust/src/structure_designer/nodes/atom_edit/operations.rs
@@ -230,10 +230,15 @@ pub fn transform_selected(structure_designer: &mut StructureDesigner, abs_transf
         let base_info: Vec<BaseAtomPromotionInfo> = if atom_edit_data.output_diff {
             Vec::new()
         } else {
-            gather_base_atom_promotion_info(
-                structure_designer,
-                &atom_edit_data.selection.selected_base_atoms,
-            )
+            // Filter out frozen base atoms so they are not moved by the transform.
+            let non_frozen_base: std::collections::HashSet<u32> = atom_edit_data
+                .selection
+                .selected_base_atoms
+                .iter()
+                .filter(|id| !atom_edit_data.frozen_base_atoms.contains(id))
+                .copied()
+                .collect();
+            gather_base_atom_promotion_info(structure_designer, &non_frozen_base)
         };
 
         (current_transform, base_info)

--- a/rust/tests/structure_designer/atom_edit_mutations_test.rs
+++ b/rust/tests/structure_designer/atom_edit_mutations_test.rs
@@ -495,3 +495,71 @@ fn test_transform_clears_bond_selection() {
 
     assert!(data.selection.selected_bonds.is_empty());
 }
+
+// =============================================================================
+// apply_transform frozen atom tests (issue #247)
+// =============================================================================
+
+/// A frozen diff atom must not be moved by apply_transform.
+/// Regression test for issue #247: frozen atoms were moved by the transform panel.
+#[test]
+fn test_apply_transform_skips_frozen_diff_atom() {
+    let mut data = AtomEditData::new();
+    // Atom 1 at (0,0,0) — will be frozen
+    let frozen_id = data.diff.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    // Atom 2 at (2,0,0) — will not be frozen
+    let free_id = data.diff.add_atom(6, DVec3::new(2.0, 0.0, 0.0));
+
+    data.selection.selected_diff_atoms.insert(frozen_id);
+    data.selection.selected_diff_atoms.insert(free_id);
+    // Centroid of the two atoms is (1, 0, 0)
+    data.selection.selection_transform =
+        Some(Transform::new(DVec3::new(1.0, 0.0, 0.0), glam::f64::DQuat::IDENTITY));
+
+    // Freeze atom 1
+    data.frozen_diff_atoms.insert(frozen_id);
+
+    // Apply a +1 x translation
+    let relative = Transform::new(DVec3::new(1.0, 0.0, 0.0), glam::f64::DQuat::IDENTITY);
+    data.apply_transform(&relative, &[]);
+
+    // Frozen atom must stay at its original position
+    let frozen_atom = data.diff.get_atom(frozen_id).unwrap();
+    assert_eq!(
+        frozen_atom.position,
+        DVec3::new(0.0, 0.0, 0.0),
+        "Frozen diff atom must not be moved by apply_transform"
+    );
+
+    // Non-frozen atom must have moved
+    let free_atom = data.diff.get_atom(free_id).unwrap();
+    assert_eq!(
+        free_atom.position,
+        DVec3::new(3.0, 0.0, 0.0),
+        "Non-frozen diff atom must be moved by apply_transform"
+    );
+}
+
+/// When all selected diff atoms are frozen, apply_transform must not move any.
+#[test]
+fn test_apply_transform_all_frozen_diff_atoms_not_moved() {
+    let mut data = AtomEditData::new();
+    let id1 = data.diff.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    let id2 = data.diff.add_atom(6, DVec3::new(2.0, 0.0, 0.0));
+
+    data.selection.selected_diff_atoms.insert(id1);
+    data.selection.selected_diff_atoms.insert(id2);
+    data.selection.selection_transform =
+        Some(Transform::new(DVec3::new(1.0, 0.0, 0.0), glam::f64::DQuat::IDENTITY));
+
+    // Freeze both atoms
+    data.frozen_diff_atoms.insert(id1);
+    data.frozen_diff_atoms.insert(id2);
+
+    let relative = Transform::new(DVec3::new(5.0, 0.0, 0.0), glam::f64::DQuat::IDENTITY);
+    data.apply_transform(&relative, &[]);
+
+    // Neither atom should have moved
+    assert_eq!(data.diff.get_atom(id1).unwrap().position, DVec3::new(0.0, 0.0, 0.0));
+    assert_eq!(data.diff.get_atom(id2).unwrap().position, DVec3::new(2.0, 0.0, 0.0));
+}

--- a/rust/tests/structure_designer/atom_edit_undo_test.rs
+++ b/rust/tests/structure_designer/atom_edit_undo_test.rs
@@ -2386,6 +2386,8 @@ fn undo_atom_edit_sequence_restores_initial_state() {
 
 use rust_lib_flutter_cad::api::structure_designer::structure_designer_api_types::DragFrozenStatus;
 use rust_lib_flutter_cad::structure_designer::nodes::atom_edit::atom_edit::drag_selected_by_delta;
+use rust_lib_flutter_cad::structure_designer::nodes::atom_edit::atom_edit::transform_selected;
+use rust_lib_flutter_cad::util::transform::Transform;
 
 #[test]
 fn drag_frozen_diff_atom_not_moved() {
@@ -2464,4 +2466,110 @@ fn drag_no_frozen_returns_none_frozen() {
     assert_eq!(atom1.position, DVec3::new(1.0, 0.0, 0.0));
 
     assert!(matches!(status, DragFrozenStatus::NoneFrozen));
+}
+
+// =============================================================================
+// Frozen atoms: drag via transform_selected (issue #247)
+// =============================================================================
+
+/// Frozen diff atom must not be moved by transform_selected.
+/// Regression test for issue #247: frozen atoms were moved by the transform panel.
+#[test]
+fn transform_selected_frozen_diff_atom_not_moved() {
+    let mut designer = setup_atom_edit();
+
+    // Add two diff atoms
+    {
+        let data = get_data_mut(&mut designer);
+        data.add_atom_recorded(6, DVec3::new(0.0, 0.0, 0.0));
+        data.add_atom_recorded(7, DVec3::new(2.0, 0.0, 0.0));
+        // Select both
+        data.selection.selected_diff_atoms.insert(1);
+        data.selection.selected_diff_atoms.insert(2);
+        // Set selection centroid (midpoint of the two atoms)
+        data.selection.selection_transform = Some(Transform::new(
+            DVec3::new(1.0, 0.0, 0.0),
+            glam::f64::DQuat::IDENTITY,
+        ));
+        // Freeze atom 1
+        data.frozen_diff_atoms.insert(1);
+    }
+
+    // Apply a transform that moves to (2, 0, 0) absolute — delta = +1 x
+    let abs_transform = Transform::new(DVec3::new(2.0, 0.0, 0.0), glam::f64::DQuat::IDENTITY);
+    with_atom_edit_undo(&mut designer, "Move atoms", |sd| {
+        transform_selected(sd, &abs_transform);
+    });
+
+    let data = get_data_mut(&mut designer);
+    // Frozen atom 1 must NOT have moved
+    let atom1 = data.diff.get_atom(1).unwrap();
+    assert_eq!(
+        atom1.position,
+        DVec3::new(0.0, 0.0, 0.0),
+        "Frozen diff atom must not be moved by transform_selected"
+    );
+    // Non-frozen atom 2 must have moved
+    let atom2 = data.diff.get_atom(2).unwrap();
+    assert_eq!(
+        atom2.position,
+        DVec3::new(3.0, 0.0, 0.0),
+        "Non-frozen diff atom must be moved by transform_selected"
+    );
+}
+
+/// When all selected diff atoms are frozen, transform_selected must not move any.
+#[test]
+fn transform_selected_all_frozen_diff_atoms_not_moved() {
+    let mut designer = setup_atom_edit();
+
+    {
+        let data = get_data_mut(&mut designer);
+        data.add_atom_recorded(6, DVec3::new(0.0, 0.0, 0.0));
+        data.add_atom_recorded(6, DVec3::new(2.0, 0.0, 0.0));
+        data.selection.selected_diff_atoms.insert(1);
+        data.selection.selected_diff_atoms.insert(2);
+        data.selection.selection_transform = Some(Transform::new(
+            DVec3::new(1.0, 0.0, 0.0),
+            glam::f64::DQuat::IDENTITY,
+        ));
+        // Freeze both atoms
+        data.frozen_diff_atoms.insert(1);
+        data.frozen_diff_atoms.insert(2);
+    }
+
+    let abs_transform = Transform::new(DVec3::new(5.0, 0.0, 0.0), glam::f64::DQuat::IDENTITY);
+    with_atom_edit_undo(&mut designer, "Move atoms", |sd| {
+        transform_selected(sd, &abs_transform);
+    });
+
+    let data = get_data_mut(&mut designer);
+    assert_eq!(data.diff.get_atom(1).unwrap().position, DVec3::new(0.0, 0.0, 0.0));
+    assert_eq!(data.diff.get_atom(2).unwrap().position, DVec3::new(2.0, 0.0, 0.0));
+}
+
+/// Frozen base atoms must not contribute to the status count when dragging
+/// (regression: drag_selected_by_delta correctly filters frozen base atoms).
+#[test]
+fn drag_frozen_base_atom_returns_all_frozen() {
+    let mut designer = setup_atom_edit();
+
+    // Manually insert a base atom ID into selected_base_atoms and freeze it.
+    // (No actual wired input — gather_base_atom_promotion_info will return empty,
+    // but frozen_count must still reflect the frozen atom.)
+    {
+        let data = get_data_mut(&mut designer);
+        data.selection.selected_base_atoms.insert(42);
+        data.frozen_base_atoms.insert(42);
+    }
+
+    begin_atom_edit_drag(&mut designer);
+    let status = drag_selected_by_delta(&mut designer, DVec3::new(1.0, 0.0, 0.0));
+    end_atom_edit_drag(&mut designer);
+
+    // The frozen base atom was the only selected atom; nothing moved.
+    assert!(
+        matches!(status, DragFrozenStatus::AllFrozen),
+        "Dragging only frozen base atoms must return AllFrozen"
+    );
 }


### PR DESCRIPTION
Fixes #247

## Root Cause

Two code paths in atom_edit were missing the frozen-atom guard: (1) apply_transform in atom_edit_data.rs iterated ALL selected diff atoms without checking frozen_diff_atoms; (2) transform_selected in operations.rs passed ALL selected_base_atoms to gather_base_atom_promotion_info without filtering frozen_base_atoms. This allowed frozen atoms to be moved via the Transform Selected panel (atom_edit_transform_selected API), even though the screen-plane drag path (drag_selected_by_delta) and XYZ gadget (sync_data) already correctly enforced the frozen guard.

## Fix

In apply_transform (atom_edit_data.rs): filter out frozen_diff_atoms when building the diff_ids list before iterating and moving atoms. In transform_selected (operations.rs): compute a non_frozen_base set by filtering selected_base_atoms against frozen_base_atoms before passing to gather_base_atom_promotion_info.

## Tests Added

- rust/tests/structure_designer/atom_edit_mutations_test.rs::test_apply_transform_skips_frozen_diff_atom
- rust/tests/structure_designer/atom_edit_mutations_test.rs::test_apply_transform_all_frozen_diff_atoms_not_moved
- rust/tests/structure_designer/atom_edit_undo_test.rs::transform_selected_frozen_diff_atom_not_moved
- rust/tests/structure_designer/atom_edit_undo_test.rs::transform_selected_all_frozen_diff_atoms_not_moved
- rust/tests/structure_designer/atom_edit_undo_test.rs::drag_frozen_base_atom_returns_all_frozen

## Files Modified

- rust/src/structure_designer/nodes/atom_edit/atom_edit_data.rs
- rust/src/structure_designer/nodes/atom_edit/operations.rs
- rust/tests/structure_designer/atom_edit_mutations_test.rs
- rust/tests/structure_designer/atom_edit_undo_test.rs
