### PR TITLE
Fix #271: relax node freezes on large atom sets

### DIFF
--- a/rust/src/crystolecule/simulation/mod.rs
+++ b/rust/src/crystolecule/simulation/mod.rs
@@ -11,6 +11,11 @@ use topology::MolecularTopology;
 use uff::UffForceField;
 use uff::VdwMode;
 
+/// Maximum number of atoms that `minimize_energy` will accept.
+/// Beyond this limit, the O(N²) nonbonded pair enumeration and per-iteration
+/// force evaluation become prohibitively expensive (issue #271).
+pub const MAX_MINIMIZE_ATOMS: usize = 2000;
+
 /// Result of an energy minimization run.
 #[derive(Debug)]
 pub struct MinimizationResult {
@@ -29,6 +34,9 @@ pub struct MinimizationResult {
 /// Updates atom positions in-place to lower-energy configurations.
 /// Atoms with the frozen flag (`atom.is_frozen()`) are held fixed.
 ///
+/// Returns an error if the structure exceeds `MAX_MINIMIZE_ATOMS` to prevent
+/// the UI from freezing on large inputs (issue #271).
+///
 /// # Arguments
 ///
 /// * `structure` - A mutable reference to the atomic structure to minimize
@@ -42,6 +50,15 @@ pub fn minimize_energy(
     structure: &mut AtomicStructure,
     vdw_mode: VdwMode,
 ) -> Result<MinimizationResult, String> {
+    let num_atoms = structure.get_num_of_atoms();
+    if num_atoms > MAX_MINIMIZE_ATOMS {
+        return Err(format!(
+            "Structure has {} atoms, which exceeds the minimization limit of {}. \
+             Large structures cause excessive computation time.",
+            num_atoms, MAX_MINIMIZE_ATOMS
+        ));
+    }
+
     let topology = match &vdw_mode {
         VdwMode::AllPairs => MolecularTopology::from_structure(structure),
         VdwMode::Cutoff(_) => MolecularTopology::from_structure_bonded_only(structure),

--- a/rust/src/structure_designer/nodes/relax.rs
+++ b/rust/src/structure_designer/nodes/relax.rs
@@ -16,6 +16,11 @@ use crate::structure_designer::node_type_registry::NodeTypeRegistry;
 use crate::structure_designer::structure_designer::StructureDesigner;
 use serde::{Deserialize, Serialize};
 
+/// Maximum number of atoms the relax node will process before returning an error.
+/// Minimization has O(N²) complexity due to nonbonded pair enumeration, so large
+/// structures would block the UI thread for an unacceptable time (issue #271).
+pub const MAX_RELAX_ATOMS: usize = 2000;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelaxData {}
 
@@ -53,6 +58,16 @@ impl NodeData for RelaxData {
         }
 
         if let NetworkResult::Atomic(mut atomic_structure) = input_val {
+            let num_atoms = atomic_structure.get_num_of_atoms();
+            if num_atoms > MAX_RELAX_ATOMS {
+                return NetworkResult::Error(format!(
+                    "Structure has {} atoms, which exceeds the relax node limit of {}. \
+                     Large structures cause excessive computation time. \
+                     Consider reducing the structure size or using a smaller region.",
+                    num_atoms, MAX_RELAX_ATOMS
+                ));
+            }
+
             let vdw_mode = if context.use_vdw_cutoff {
                 VdwMode::Cutoff(6.0)
             } else {

--- a/rust/tests/crystolecule.rs
+++ b/rust/tests/crystolecule.rs
@@ -69,3 +69,6 @@ mod guided_placement_test;
 
 #[path = "crystolecule/hydrogen_passivation_test.rs"]
 mod hydrogen_passivation_test;
+
+#[path = "crystolecule/simulation/relax_atom_limit_test.rs"]
+mod relax_atom_limit_test;

--- a/rust/tests/crystolecule/simulation/relax_atom_limit_test.rs
+++ b/rust/tests/crystolecule/simulation/relax_atom_limit_test.rs
@@ -1,0 +1,113 @@
+// Tests for atom count limits in minimize_energy (issue #271).
+//
+// Verifies that minimize_energy returns an error for structures exceeding
+// MAX_MINIMIZE_ATOMS, preventing UI freezes from O(N²) computation.
+
+use glam::DVec3;
+use rust_lib_flutter_cad::crystolecule::atomic_structure::AtomicStructure;
+use rust_lib_flutter_cad::crystolecule::simulation::{minimize_energy, MAX_MINIMIZE_ATOMS};
+use rust_lib_flutter_cad::crystolecule::simulation::uff::VdwMode;
+
+/// Creates an atomic structure with `n` disconnected carbon atoms on a grid.
+fn create_large_structure(n: usize) -> AtomicStructure {
+    let mut structure = AtomicStructure::new();
+    let spacing = 2.0; // Angstroms apart to avoid auto-bonding
+    let side = (n as f64).cbrt().ceil() as usize;
+    let mut count = 0;
+    for ix in 0..side {
+        for iy in 0..side {
+            for iz in 0..side {
+                if count >= n {
+                    return structure;
+                }
+                let pos = DVec3::new(ix as f64 * spacing, iy as f64 * spacing, iz as f64 * spacing);
+                structure.add_atom(6, pos); // Carbon
+                count += 1;
+            }
+        }
+    }
+    structure
+}
+
+#[test]
+fn minimize_energy_rejects_structure_exceeding_limit_allpairs() {
+    let n = MAX_MINIMIZE_ATOMS + 1;
+    let mut structure = create_large_structure(n);
+    assert_eq!(structure.get_num_of_atoms(), n);
+
+    let result = minimize_energy(&mut structure, VdwMode::AllPairs);
+    assert!(result.is_err(), "Expected error for {} atoms with AllPairs mode", n);
+
+    let err_msg = result.unwrap_err();
+    assert!(
+        err_msg.contains(&n.to_string()),
+        "Error should mention atom count {}: {}",
+        n, err_msg
+    );
+    assert!(
+        err_msg.contains(&MAX_MINIMIZE_ATOMS.to_string()),
+        "Error should mention limit {}: {}",
+        MAX_MINIMIZE_ATOMS, err_msg
+    );
+}
+
+#[test]
+fn minimize_energy_rejects_structure_exceeding_limit_cutoff() {
+    let n = MAX_MINIMIZE_ATOMS + 1;
+    let mut structure = create_large_structure(n);
+
+    let result = minimize_energy(&mut structure, VdwMode::Cutoff(6.0));
+    assert!(result.is_err(), "Expected error for {} atoms with Cutoff mode", n);
+}
+
+#[test]
+fn minimize_energy_accepts_structure_at_limit() {
+    // A structure exactly at the limit should be accepted (not rejected).
+    // Use a small molecule to keep test fast.
+    let mut structure = AtomicStructure::new();
+    let a1 = structure.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    let a2 = structure.add_atom(6, DVec3::new(1.54, 0.0, 0.0));
+    structure.add_bond(a1, a2, 1);
+
+    let result = minimize_energy(&mut structure, VdwMode::AllPairs);
+    assert!(result.is_ok(), "Small structure should be accepted: {:?}", result.err());
+}
+
+#[test]
+fn minimize_energy_accepts_empty_structure() {
+    let mut structure = AtomicStructure::new();
+    let result = minimize_energy(&mut structure, VdwMode::AllPairs);
+    assert!(result.is_ok());
+    let res = result.unwrap();
+    assert_eq!(res.iterations, 0);
+    assert!(res.converged);
+}
+
+#[test]
+fn minimize_energy_limit_value_is_reasonable() {
+    // The limit should be between 500 and 5000 — large enough for typical use
+    // but small enough to prevent UI freezes with O(N²) computation.
+    assert!(
+        MAX_MINIMIZE_ATOMS >= 500,
+        "Limit {} is too low for practical use",
+        MAX_MINIMIZE_ATOMS
+    );
+    assert!(
+        MAX_MINIMIZE_ATOMS <= 5000,
+        "Limit {} may be too high to prevent UI freezes",
+        MAX_MINIMIZE_ATOMS
+    );
+}
+
+#[test]
+fn minimize_energy_rejects_7000_atoms() {
+    // Reproduces issue #271: ~7000 atoms should be rejected immediately.
+    let mut structure = create_large_structure(7000);
+    assert_eq!(structure.get_num_of_atoms(), 7000);
+
+    let result = minimize_energy(&mut structure, VdwMode::AllPairs);
+    assert!(
+        result.is_err(),
+        "7000 atoms must be rejected to prevent UI freeze (issue #271)"
+    );
+}

--- a/rust/tests/structure_designer.rs
+++ b/rust/tests/structure_designer.rs
@@ -120,3 +120,6 @@ mod continuous_minimization_test;
 
 #[path = "structure_designer/cli_access_rules_test.rs"]
 mod cli_access_rules_test;
+
+#[path = "structure_designer/relax_node_atom_limit_test.rs"]
+mod relax_node_atom_limit_test;

--- a/rust/tests/structure_designer/relax_node_atom_limit_test.rs
+++ b/rust/tests/structure_designer/relax_node_atom_limit_test.rs
@@ -1,0 +1,34 @@
+// Tests for relax node atom count limit (issue #271).
+//
+// The relax node delegates to minimize_energy(), which enforces MAX_MINIMIZE_ATOMS.
+// The relax node also has its own MAX_RELAX_ATOMS guard for early rejection before
+// any expensive computation.
+
+use rust_lib_flutter_cad::crystolecule::simulation::MAX_MINIMIZE_ATOMS;
+use rust_lib_flutter_cad::structure_designer::nodes::relax::MAX_RELAX_ATOMS;
+
+#[test]
+fn relax_node_max_atoms_constant_is_reasonable() {
+    // The limit should be between 500 and 5000 — large enough for typical use
+    // but small enough to prevent UI freezes with O(N²) computation.
+    assert!(
+        MAX_RELAX_ATOMS >= 500,
+        "MAX_RELAX_ATOMS {} is too low for practical use",
+        MAX_RELAX_ATOMS
+    );
+    assert!(
+        MAX_RELAX_ATOMS <= 5000,
+        "MAX_RELAX_ATOMS {} may be too high to prevent UI freezes",
+        MAX_RELAX_ATOMS
+    );
+}
+
+#[test]
+fn relax_node_limit_matches_minimize_energy_limit() {
+    // Both guards should use the same limit value to ensure consistent behavior.
+    assert_eq!(
+        MAX_RELAX_ATOMS, MAX_MINIMIZE_ATOMS,
+        "Relax node limit ({}) should match minimize_energy limit ({})",
+        MAX_RELAX_ATOMS, MAX_MINIMIZE_ATOMS
+    );
+}


### PR DESCRIPTION
Fixes #271

## Root Cause

The relax node calls minimize_energy() with no atom count guard. Minimization uses O(N²) nonbonded pair enumeration (VdwMode::AllPairs) and runs up to 500 L-BFGS iterations, each evaluating all pairs. For ~7000 atoms this means ~24.5M pairs × 500 iterations = billions of float operations on the UI thread, causing an indefinite freeze.

## Fix

Added MAX_RELAX_ATOMS=2000 constant in relax.rs with an early guard in eval() that returns NetworkResult::Error before any expensive computation. Added matching MAX_MINIMIZE_ATOMS=2000 guard in minimize_energy() (simulation/mod.rs) as a safety net. Both return descriptive error messages mentioning the atom count and limit.

## Tests Added

- relax_atom_limit_test::minimize_energy_rejects_structure_exceeding_limit_allpairs
- relax_atom_limit_test::minimize_energy_rejects_structure_exceeding_limit_cutoff
- relax_atom_limit_test::minimize_energy_accepts_structure_at_limit
- relax_atom_limit_test::minimize_energy_accepts_empty_structure
- relax_atom_limit_test::minimize_energy_limit_value_is_reasonable
- relax_atom_limit_test::minimize_energy_rejects_7000_atoms
- relax_node_atom_limit_test::relax_node_max_atoms_constant_is_reasonable
- relax_node_atom_limit_test::relax_node_limit_matches_minimize_energy_limit

## Files Modified

- rust/src/structure_designer/nodes/relax.rs
- rust/src/crystolecule/simulation/mod.rs
- rust/tests/crystolecule/simulation/relax_atom_limit_test.rs
- rust/tests/structure_designer/relax_node_atom_limit_test.rs
- rust/tests/crystolecule.rs
- rust/tests/structure_designer.rs
