### PR TITLE
Fix #257

### DIFF
--- a/rust/src/crystolecule/atomic_structure/mod.rs
+++ b/rust/src/crystolecule/atomic_structure/mod.rs
@@ -203,6 +203,41 @@ impl AtomicStructure {
         }
     }
 
+    /// Copies all per-atom metadata (flags except selected, and in_crystal_depth)
+    /// from a source atom to a target atom in this structure.
+    ///
+    /// The `selected` flag is intentionally NOT copied because it is transient UI
+    /// state that should not persist through diff application or structure merging.
+    ///
+    /// This is the canonical way to preserve metadata when constructing result atoms
+    /// via `add_atom()` (which initializes all metadata to zero). Using this method
+    /// instead of copying individual flags ensures that newly added metadata fields
+    /// are automatically preserved without requiring updates at every call site.
+    pub(crate) fn copy_atom_metadata(&mut self, target_id: u32, source: &Atom) {
+        if let Some(target) = self.get_atom_mut(target_id) {
+            // Copy all flags except selected (bit 0)
+            target.flags = source.flags & !0x1;
+            target.in_crystal_depth = source.in_crystal_depth;
+        }
+    }
+
+    /// Merges metadata from two source atoms into a target atom using OR semantics
+    /// for flags (except selected) and taking in_crystal_depth from the primary source.
+    ///
+    /// Used when a diff atom replaces/moves a base atom: if either source has a flag
+    /// set (e.g. frozen), the result inherits it.
+    pub(crate) fn merge_atom_metadata(
+        &mut self,
+        target_id: u32,
+        primary: &Atom,
+        secondary: &Atom,
+    ) {
+        if let Some(target) = self.get_atom_mut(target_id) {
+            target.flags = (primary.flags | secondary.flags) & !0x1;
+            target.in_crystal_depth = primary.in_crystal_depth;
+        }
+    }
+
     pub fn has_selected_atoms(&self) -> bool {
         self.atoms
             .iter()

--- a/rust/src/crystolecule/atomic_structure_diff.rs
+++ b/rust/src/crystolecule/atomic_structure_diff.rs
@@ -124,9 +124,7 @@ pub fn apply_diff(
             // Matched UNCHANGED marker → base atom passes through unchanged
             // but we still record the mapping so bond resolution works
             let result_id = result.add_atom(base_atom.atomic_number, base_atom.position);
-            if base_atom.is_frozen() {
-                result.set_atom_frozen(result_id, true);
-            }
+            result.copy_atom_metadata(result_id, base_atom);
             provenance.sources.insert(
                 result_id,
                 AtomSource::DiffMatchedBase {
@@ -141,9 +139,7 @@ pub fn apply_diff(
             // Matched normal atom → replacement/move
             // Use the diff atom's position (which may differ from base for moves)
             let result_id = result.add_atom(diff_atom.atomic_number, diff_atom.position);
-            if base_atom.is_frozen() || diff_atom.is_frozen() {
-                result.set_atom_frozen(result_id, true);
-            }
+            result.merge_atom_metadata(result_id, diff_atom, base_atom);
             provenance.sources.insert(
                 result_id,
                 AtomSource::DiffMatchedBase {
@@ -185,9 +181,7 @@ pub fn apply_diff(
         }
 
         let result_id = result.add_atom(diff_atom.atomic_number, diff_atom.position);
-        if diff_atom.is_frozen() {
-            result.set_atom_frozen(result_id, true);
-        }
+        result.copy_atom_metadata(result_id, diff_atom);
         provenance
             .sources
             .insert(result_id, AtomSource::DiffAdded(diff_id));
@@ -203,9 +197,7 @@ pub fn apply_diff(
         }
         // Not matched and not deleted → pass through
         let result_id = result.add_atom(base_atom.atomic_number, base_atom.position);
-        if base_atom.is_frozen() {
-            result.set_atom_frozen(result_id, true);
-        }
+        result.copy_atom_metadata(result_id, base_atom);
         provenance
             .sources
             .insert(result_id, AtomSource::BasePassthrough(base_atom.id));

--- a/rust/tests/crystolecule/atomic_structure_diff_test.rs
+++ b/rust/tests/crystolecule/atomic_structure_diff_test.rs
@@ -1591,7 +1591,7 @@ fn frozen_flag_propagates_through_chained_apply_diff() {
     // Base: two carbons, first one frozen
     let mut base = AtomicStructure::new();
     let c1 = base.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
-    let c2 = base.add_atom(6, DVec3::new(3.0, 0.0, 0.0));
+    let _c2 = base.add_atom(6, DVec3::new(3.0, 0.0, 0.0));
     base.set_atom_frozen(c1, true);
 
     // First diff: empty (passthrough)
@@ -1640,4 +1640,223 @@ fn frozen_flag_from_base_preserved_on_matched_replacement() {
         result_atom.is_frozen(),
         "Frozen flag from base should be preserved on matched replacement"
     );
+}
+
+// ============================================================================
+// Metadata preservation tests (issue #257)
+// ============================================================================
+// These tests verify that ALL per-atom metadata (frozen flag, hydrogen_passivation
+// flag, in_crystal_depth, and future flags) pass through apply_diff() unchanged.
+
+#[test]
+fn frozen_metadata_passthrough_base_atom() {
+    // Case 4: Unmatched base atom should preserve frozen flag
+    let mut base = AtomicStructure::new();
+    let c1 = base.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    let c2 = base.add_atom(6, DVec3::new(5.0, 0.0, 0.0));
+    base.set_atom_frozen(c1, true);
+    base.set_atom_frozen(c2, true);
+
+    // Diff adds an atom far away — base atoms are unmatched pass-throughs
+    let mut diff = AtomicStructure::new_diff();
+    diff.add_atom(7, DVec3::new(10.0, 0.0, 0.0));
+
+    let result = apply_diff(&base, &diff, DEFAULT_TOLERANCE);
+    assert_eq!(result.result.get_num_of_atoms(), 3);
+
+    // Check that base pass-through atoms retained their frozen flag
+    for (_, atom) in result.result.iter_atoms() {
+        if atom.atomic_number == 6 {
+            assert!(
+                atom.is_frozen(),
+                "Base pass-through atom should preserve frozen flag"
+            );
+        }
+    }
+}
+
+#[test]
+fn hydrogen_passivation_metadata_passthrough_base_atom() {
+    // Case 4: Unmatched base atom should preserve hydrogen_passivation flag
+    let mut base = AtomicStructure::new();
+    let h1 = base.add_atom(1, DVec3::new(0.0, 0.0, 0.0));
+    base.set_atom_hydrogen_passivation(h1, true);
+
+    // Empty diff — base atom is unmatched pass-through
+    let diff = AtomicStructure::new_diff();
+
+    let result = apply_diff(&base, &diff, DEFAULT_TOLERANCE);
+    assert_eq!(result.result.get_num_of_atoms(), 1);
+
+    let result_atom = result.result.atoms_values().next().unwrap();
+    assert!(
+        result_atom.is_hydrogen_passivation(),
+        "Base pass-through atom should preserve hydrogen_passivation flag"
+    );
+}
+
+#[test]
+fn in_crystal_depth_metadata_passthrough_base_atom() {
+    // Case 4: Unmatched base atom should preserve in_crystal_depth
+    let mut base = AtomicStructure::new();
+    let c1 = base.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    base.set_atom_in_crystal_depth(c1, 2.5);
+
+    // Empty diff — base atom is unmatched pass-through
+    let diff = AtomicStructure::new_diff();
+
+    let result = apply_diff(&base, &diff, DEFAULT_TOLERANCE);
+    assert_eq!(result.result.get_num_of_atoms(), 1);
+
+    let result_atom = result.result.atoms_values().next().unwrap();
+    assert!(
+        (result_atom.in_crystal_depth - 2.5).abs() < 1e-6,
+        "Base pass-through atom should preserve in_crystal_depth, got {}",
+        result_atom.in_crystal_depth
+    );
+}
+
+#[test]
+fn hydrogen_passivation_metadata_unchanged_marker() {
+    // Case 1: UNCHANGED marker match should preserve hydrogen_passivation from base
+    let mut base = AtomicStructure::new();
+    let c1 = base.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    base.set_atom_hydrogen_passivation(c1, true);
+    base.set_atom_in_crystal_depth(c1, 1.5);
+
+    let mut diff = AtomicStructure::new_diff();
+    diff.add_atom(UNCHANGED_ATOMIC_NUMBER, DVec3::new(0.0, 0.0, 0.0));
+
+    let result = apply_diff(&base, &diff, DEFAULT_TOLERANCE);
+    assert_eq!(result.result.get_num_of_atoms(), 1);
+
+    let result_atom = result.result.atoms_values().next().unwrap();
+    assert!(
+        result_atom.is_hydrogen_passivation(),
+        "UNCHANGED marker match should preserve hydrogen_passivation from base"
+    );
+    assert!(
+        (result_atom.in_crystal_depth - 1.5).abs() < 1e-6,
+        "UNCHANGED marker match should preserve in_crystal_depth from base"
+    );
+}
+
+#[test]
+fn hydrogen_passivation_metadata_replacement() {
+    // Case 2: Matched replacement should merge hydrogen_passivation with OR semantics
+    let mut base = AtomicStructure::new();
+    let c1 = base.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    base.set_atom_hydrogen_passivation(c1, true);
+
+    let mut diff = AtomicStructure::new_diff();
+    diff.add_atom(7, DVec3::new(0.0, 0.0, 0.0)); // Replace C with N
+
+    let result = apply_diff(&base, &diff, DEFAULT_TOLERANCE);
+    assert_eq!(result.result.get_num_of_atoms(), 1);
+
+    let result_atom = result.result.atoms_values().next().unwrap();
+    assert_eq!(result_atom.atomic_number, 7, "Should be nitrogen");
+    assert!(
+        result_atom.is_hydrogen_passivation(),
+        "Replacement should preserve hydrogen_passivation from base via OR merge"
+    );
+}
+
+#[test]
+fn in_crystal_depth_metadata_replacement() {
+    // Case 2: Matched replacement should take in_crystal_depth from diff (primary)
+    let mut base = AtomicStructure::new();
+    let c1 = base.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    base.set_atom_in_crystal_depth(c1, 1.0);
+
+    let mut diff = AtomicStructure::new_diff();
+    let d1 = diff.add_atom(7, DVec3::new(0.0, 0.0, 0.0));
+    diff.set_atom_in_crystal_depth(d1, 3.0);
+
+    let result = apply_diff(&base, &diff, DEFAULT_TOLERANCE);
+    assert_eq!(result.result.get_num_of_atoms(), 1);
+
+    let result_atom = result.result.atoms_values().next().unwrap();
+    assert!(
+        (result_atom.in_crystal_depth - 3.0).abs() < 1e-6,
+        "Replacement should take in_crystal_depth from diff (primary), got {}",
+        result_atom.in_crystal_depth
+    );
+}
+
+#[test]
+fn hydrogen_passivation_metadata_diff_addition() {
+    // Case 3: Unmatched diff addition should preserve hydrogen_passivation
+    let base = AtomicStructure::new();
+
+    let mut diff = AtomicStructure::new_diff();
+    let h1 = diff.add_atom(1, DVec3::new(0.0, 0.0, 0.0));
+    diff.set_atom_hydrogen_passivation(h1, true);
+    diff.set_atom_in_crystal_depth(h1, 4.0);
+
+    let result = apply_diff(&base, &diff, DEFAULT_TOLERANCE);
+    assert_eq!(result.result.get_num_of_atoms(), 1);
+
+    let result_atom = result.result.atoms_values().next().unwrap();
+    assert!(
+        result_atom.is_hydrogen_passivation(),
+        "Diff addition should preserve hydrogen_passivation"
+    );
+    assert!(
+        (result_atom.in_crystal_depth - 4.0).abs() < 1e-6,
+        "Diff addition should preserve in_crystal_depth, got {}",
+        result_atom.in_crystal_depth
+    );
+}
+
+#[test]
+fn selected_flag_not_propagated() {
+    // Selected flag is UI state and should NOT be copied through apply_diff()
+    let mut base = AtomicStructure::new();
+    let c1 = base.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    base.set_atom_selected(c1, true);
+
+    let diff = AtomicStructure::new_diff();
+
+    let result = apply_diff(&base, &diff, DEFAULT_TOLERANCE);
+    let result_atom = result.result.atoms_values().next().unwrap();
+    assert!(
+        !result_atom.is_selected(),
+        "Selected flag should NOT be propagated through apply_diff()"
+    );
+}
+
+#[test]
+fn all_metadata_combined_passthrough() {
+    // Comprehensive test: base atom with ALL metadata set passes through unchanged
+    let mut base = AtomicStructure::new();
+    let c1 = base.add_atom(6, DVec3::new(0.0, 0.0, 0.0));
+    base.set_atom_frozen(c1, true);
+    base.set_atom_hydrogen_passivation(c1, true);
+    base.set_atom_in_crystal_depth(c1, 7.5);
+
+    // Diff modifies a different atom far away
+    let mut diff = AtomicStructure::new_diff();
+    diff.add_atom(7, DVec3::new(20.0, 0.0, 0.0));
+
+    let result = apply_diff(&base, &diff, DEFAULT_TOLERANCE);
+
+    // Find the carbon (pass-through)
+    let c_atom = result
+        .result
+        .atoms_values()
+        .find(|a| a.atomic_number == 6)
+        .expect("Carbon should exist in result");
+
+    assert!(c_atom.is_frozen(), "frozen flag lost on pass-through");
+    assert!(
+        c_atom.is_hydrogen_passivation(),
+        "hydrogen_passivation flag lost on pass-through"
+    );
+    assert!(
+        (c_atom.in_crystal_depth - 7.5).abs() < 1e-6,
+        "in_crystal_depth lost on pass-through, got {}",
+        c_atom.in_crystal_depth
+    );
+    assert!(!c_atom.is_selected(), "selected should not propagate");
 }


### PR DESCRIPTION
Fixes #257

## Root Cause

apply_diff() in atomic_structure_diff.rs uses add_atom() which initializes all atom metadata (flags and in_crystal_depth) to zero. Only the frozen flag was explicitly copied back from source atoms at each of the 4 add_atom() call sites. The hydrogen_passivation flag and in_crystal_depth field were silently dropped for all atom types: pass-through base atoms, unchanged marker matches, matched replacements/moves, and unmatched diff additions.

## Fix

Added two pub(crate) helper methods to AtomicStructure: copy_atom_metadata() copies all flags (except selected) and in_crystal_depth from a single source atom, and merge_atom_metadata() merges flags with OR semantics from two source atoms. Updated all 4 add_atom() call sites in apply_diff() to use these helpers instead of selective frozen-only copying. This approach is future-proof: new metadata fields added to Atom will automatically be preserved without updating each call site.

## Tests Added

- frozen_metadata_passthrough_base_atom
- hydrogen_passivation_metadata_passthrough_base_atom
- in_crystal_depth_metadata_passthrough_base_atom
- hydrogen_passivation_metadata_unchanged_marker
- hydrogen_passivation_metadata_replacement
- in_crystal_depth_metadata_replacement
- hydrogen_passivation_metadata_diff_addition
- selected_flag_not_propagated
- all_metadata_combined_passthrough

## Files Modified

- rust/src/crystolecule/atomic_structure_diff.rs
- rust/src/crystolecule/atomic_structure/mod.rs
- rust/tests/crystolecule/atomic_structure_diff_test.rs

## Reproduction

1. Create a base AtomicStructure with an atom that has hydrogen_passivation=true or in_crystal_depth>0.
2. Create an empty diff structure.
3. Call apply_diff(base, diff, 0.1).
4. Check the result atom: hydrogen_passivation will be false and in_crystal_depth will be 0.0 (both lost).
5. After fix: both metadata fields are preserved.

**Fixture:** `rust/tests/crystolecule/atomic_structure_diff_test.rs (tests prefixed with hydrogen_passivation_metadata_ and in_crystal_depth_metadata_)`
